### PR TITLE
Print tf

### DIFF
--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -8,6 +8,7 @@
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
 #include <tf_conversions/tf_eigen.h>
 
+#include <tf/transform_broadcaster.h>
 
 namespace MavStateEst {
 class ROSFrontEnd {
@@ -82,6 +83,9 @@ private:
 
     ros::Publisher pose_pub_;
     ros::Publisher twist_pub_;
+    tf::TransformBroadcaster tf_broadcaster_;
+    tf::StampedTransform tf_pose_;
+    bool publish_tf_ = false;
 
     geometry_msgs::PoseWithCovarianceStamped pose_msg_;
     geometry_msgs::TwistWithCovarianceStamped twist_msg_;
@@ -252,6 +256,12 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
 
             // fill in time
             pose_msg_.header.stamp = ros::Time().fromNSec(head_state.utime * 1000);
+            if(publish_tf_){
+                tf_pose_.setOrigin(temp_v3);
+                tf_pose_.setRotation(temp_q);
+                tf_pose_.stamp_ = ros::Time::now();
+                tf_broadcaster_.sendTransform(tf_pose_);
+            }
 
             // TODO insert appropriate covariance into the message
             // publish the pose

--- a/pronto_ros/src/ros_frontend.cpp
+++ b/pronto_ros/src/ros_frontend.cpp
@@ -29,12 +29,29 @@ ROSFrontEnd::ROSFrontEnd(ros::NodeHandle& nh, bool verbose) :
                 twist_pub_ = nh_.advertise<geometry_msgs::TwistWithCovarianceStamped>(twist_topic, 200);
                 twist_msg_.header.frame_id = twist_frame_id;
             }
+            // try to
+            if(!nh_.getParam("publish_tf", publish_tf_)){
+                ROS_WARN("Couldn't get param \"publish_tf\". Not publishing TF.");
+            }
+            if(publish_tf_){
+                std::string tf_child_frame_id = "base";
+                if(!nh_.getParam("tf_child_frame_id", tf_child_frame_id)){
+                    ROS_WARN("Couldn't get param \"tf_frame_id\". Setting default to \"base\".");
+                }
+                tf_pose_.frame_id_ = pose_frame_id;
+                // NOTE implicitly assuming the twist frame id is the base frame
+                tf_pose_.child_frame_id_ = tf_child_frame_id;
+                ROS_INFO_STREAM("Publishing TF with frame_id: \"" << tf_pose_.frame_id_ << "\" and child_frame_id: \"" << tf_pose_.child_frame_id_ << "\"");
+            }
         }
-        int history_span;
-        nh_.getParam("utime_history_span", history_span);
-        history_span_ = history_span;
+
     }
 
+    int history_span = 1e6; // keep 1 second as default
+    if(!nh_.getParam("utime_history_span", history_span)){
+     ROS_WARN_STREAM("Couldn't get param \"utime_history_span\". Setting default to \"" << history_span << "\"");
+    }
+    history_span_ = history_span;
     initializeState();
     initializeCovariance();
     if(verbose_){


### PR DESCRIPTION
This PR allows to publish a TF from the filter.
Also, the subscription in the ROS frontend is optional, so that it can be skipped in case one wants to call the callbacks manually