### PR TITLE
No forward propagation experimental

### DIFF
--- a/pronto_core/include/pronto_core/ins_module.hpp
+++ b/pronto_core/include/pronto_core/ins_module.hpp
@@ -18,6 +18,8 @@ public:
     int num_to_init = 100;
     double max_initial_gyro_bias = 0.015;
 
+    bool ignore_accel = false;
+
     bool gyro_bias_update_online = true;
     Eigen::Vector3d gyro_bias_initial = Eigen::Vector3d::Zero();
     bool gyro_bias_recalc_at_start = true;
@@ -92,6 +94,7 @@ protected:
   bool accel_bias_update_online;
   Eigen::Vector3d accel_bias_initial;
   bool accel_bias_recalc_at_start;
+  bool ignore_accel = false;
 
 };
 }

--- a/pronto_core/include/pronto_core/mav_state_est.hpp
+++ b/pronto_core/include/pronto_core/mav_state_est.hpp
@@ -35,6 +35,8 @@ public:
 
   double getMeasurementsLogLikelihood() const;
   void EKFSmoothBackwardsPass(double dt);
+private:
+  bool verbose_ = false;
 
 };
 

--- a/pronto_core/include/pronto_core/rbis.hpp
+++ b/pronto_core/include/pronto_core/rbis.hpp
@@ -100,6 +100,9 @@ public:
       pose_iso.rotate(this->orientation());
       return pose_iso;
     }
+private:
+  bool debug_ = false;
+  uint64_t debug_utime_ = 0;
 
 };
 

--- a/pronto_core/include/pronto_core/rbis.hpp
+++ b/pronto_core/include/pronto_core/rbis.hpp
@@ -107,7 +107,22 @@ typedef RBIS::MatrixNd RBIM;
 
 void getIMUProcessLinearizationContinuous(const RBIS & state, RBIM & Ac);
 
-void insUpdateState(const Eigen::Vector3d & gyro, const Eigen::Vector3d & accelerometer, double dt, RBIS & state);
+/**
+ * @brief insUpdateState integrates a gyro and accelerometer measurements given
+ * a delta time. Optionally, it skips the acceleration integration.
+ * @param[in] gyro angular velocity measurement, in rad / s, base frame
+ * @param[in] accelerometer proper acceleration (= 1 g at rest) in m / s^2
+ * @param[in] dt integration constant in s
+ * @param[out] state resulting state. If the state had already linear velocity
+ * values, they get integrated too.
+ * @param[in] ignore_accel (optional) if true, this will skip the accelerometer
+ * integration and use the velocity provided by state
+ */
+void insUpdateState(const Eigen::Vector3d & gyro,
+                    const Eigen::Vector3d & accelerometer,
+                    double dt,
+                    RBIS & state,
+                    const bool &ignore_accel = false);
 
 void insUpdateCovariance(double q_gyro, double q_accel, double q_gyro_bias, double q_accel_bias, const RBIS & state,
     RBIM & cov, double dt);

--- a/pronto_core/include/pronto_core/rbis_update_interface.hpp
+++ b/pronto_core/include/pronto_core/rbis_update_interface.hpp
@@ -69,6 +69,7 @@ public:
   double q_accel;
   double q_gyro_bias;
   double q_accel_bias;
+  bool ignore_accel_ = false;
 
   RBISIMUProcessStep(const Eigen::Vector3d & gyro_,
                      const Eigen::Vector3d & accelerometer_,
@@ -77,7 +78,8 @@ public:
                      double q_gyro_bias_,
                      double q_accel_bias_,
                      double dt_,
-                     int64_t utime) :
+                     int64_t utime,
+                     bool ignore_accel = false) :
       RBISUpdateInterface(ins, utime),
       gyro(gyro_),
       accelerometer(accelerometer_),
@@ -85,7 +87,8 @@ public:
       q_accel(q_accel_),
       q_gyro_bias(q_gyro_bias_),
       q_accel_bias(q_accel_bias_),
-      dt(dt_)
+      dt(dt_),
+      ignore_accel_(ignore_accel)
   {
   }
 

--- a/pronto_core/src/ins_module.cpp
+++ b/pronto_core/src/ins_module.cpp
@@ -24,7 +24,8 @@ InsModule::InsModule(const InsConfig &config, const Eigen::Affine3d &ins_to_body
     gyro_bias_recalc_at_start(config.gyro_bias_recalc_at_start),
     accel_bias_update_online(config.accel_bias_update_online),
     accel_bias_initial(config.accel_bias_initial),
-    accel_bias_recalc_at_start(config.accel_bias_recalc_at_start)
+    accel_bias_recalc_at_start(config.accel_bias_recalc_at_start),
+    ignore_accel(config.ignore_accel)
 {
     cov_accel = std::pow(config.cov_accel, 2);
     cov_gyro = std::pow(config.cov_gyro * M_PI / 180.0, 2);
@@ -62,7 +63,8 @@ RBISUpdateInterface * InsModule::processMessage(const ImuMeasurement * msg,
                                                       cov_gyro_bias,
                                                       cov_accel_bias,
                                                       dt,
-                                                      msg->utime);
+                                                      msg->utime,
+                                                      this->ignore_accel);
 
     // Reset the bias values to the original value, if requested
     if(!gyro_bias_update_online) {

--- a/pronto_core/src/mav_state_est.cpp
+++ b/pronto_core/src/mav_state_est.cpp
@@ -92,8 +92,9 @@ bool MavStateEstimator::getInterpolatedPose(const uint64_t &utime,
 
 void MavStateEstimator::addUpdate(RBISUpdateInterface * update, bool roll_forward)
 {
-
-    std::cerr << "[ " << update->utime <<" ] "<< update->getSensorIdString() << std::endl;
+    if(verbose_){
+        std::cout << "[ " << update->utime <<" ] "<< update->getSensorIdString() << std::endl;
+    }
   // Add current update to history
   updateHistory::historyMapIterator added_it = history.addToHistory(update);
 

--- a/pronto_core/src/mav_state_est.cpp
+++ b/pronto_core/src/mav_state_est.cpp
@@ -92,6 +92,8 @@ bool MavStateEstimator::getInterpolatedPose(const uint64_t &utime,
 
 void MavStateEstimator::addUpdate(RBISUpdateInterface * update, bool roll_forward)
 {
+
+    std::cerr << "[ " << update->utime <<" ] "<< update->getSensorIdString() << std::endl;
   // Add current update to history
   updateHistory::historyMapIterator added_it = history.addToHistory(update);
 

--- a/pronto_core/src/rbis.cpp
+++ b/pronto_core/src/rbis.cpp
@@ -62,10 +62,13 @@ void insUpdateState(const Eigen::Vector3d & gyro, const Eigen::Vector3d & accele
 
   //compute derivatives
   RBIS dstate; //initialize everything to 0
-  dstate.velocity() = -state.angularVelocity().cross(state.velocity());
-  dstate.velocity().noalias() += state.quat.inverse() * g_vec + state.acceleration();
 
-  dstate.velocity() = Eigen::Vector3d::Zero();
+  if(ignore_accel){
+      dstate.velocity() = Eigen::Vector3d::Zero();
+  } else {
+      dstate.velocity() = -state.angularVelocity().cross(state.velocity());
+      dstate.velocity().noalias() += state.quat.inverse() * g_vec + state.acceleration();
+  }
 
   dstate.chi() = state.angularVelocity();
   dstate.position().noalias() = state.quat * state.velocity();

--- a/pronto_core/src/rbis.cpp
+++ b/pronto_core/src/rbis.cpp
@@ -56,8 +56,12 @@ void insUpdateState(const Eigen::Vector3d & gyro, const Eigen::Vector3d & accele
   dstate.velocity() = -state.angularVelocity().cross(state.velocity());
   dstate.velocity().noalias() += state.quat.inverse() * g_vec + state.acceleration();
 
+  dstate.velocity() = Eigen::Vector3d::Zero();
+
   dstate.chi() = state.angularVelocity();
   dstate.position().noalias() = state.quat * state.velocity();
+  // add second order?
+  // dstate.position().noalias() += + 0.5 * state.quat.inverse() * g_vec * dt + 0.5 * state.quat * state.acceleration() * dt;
 
   //integrate
   dstate.vec *= dt;

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -45,7 +45,7 @@ void RBISIMUProcessStep::updateFilter(const RBIS & prior_state, const RBIM & pri
   // TODO if this was meant to measure some sort of performance
   // replace with non-libbot calls
   // bot_tictoc("insUpdateState");
-  insUpdateState(gyro, accelerometer, dt, posterior_state);
+  insUpdateState(gyro, accelerometer, dt, posterior_state, ignore_accel_);
   insUpdateCovariance(q_gyro, q_accel, q_gyro_bias, q_accel_bias, prior_state, posterior_covariance, dt);
   // bot_tictoc("insUpdateState");
 

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -217,13 +217,15 @@ void ROSFrontEnd::initCallback(boost::shared_ptr<MsgT const> msg, const SensorId
     }
 }
 
+//TODO come up with a better way to activate / deactivate debug mode
+#define DEBUG_MODE 0
 
 template <class MsgT>
 void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& sensor_id)
 {
-    //if(verbose_){
+#if DEBUG_MODE
         ROS_INFO_STREAM("Callback for sensor " << sensor_id);
-    //}
+#endif
     // this is a generic templated callback that does the same for every module:
     // if the module is initialized and the filter is ready
     // 1) take the measurement update and pass it to the filter if valid
@@ -232,12 +234,15 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
         // appropriate casting to the right type and call to the process message
         // function to get the update
         // Record start time
+#if DEBUG_MODE
         auto start = std::chrono::high_resolution_clock::now();
+#endif
         RBISUpdateInterface* update = static_cast<SensingModule<MsgT>*>(active_modules_[sensor_id])->processMessage(msg.get(), state_est_.get());
+#if DEBUG_MODE
         auto end = std::chrono::high_resolution_clock::now();
-
         ROS_INFO_STREAM("Time elapsed process message: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
         start = end;
+#endif
         // if the update is invalid, we leave
         if(update == NULL){
             std::cout << "Invalid update" << std::endl;
@@ -246,10 +251,11 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
         }
         // tell also the filter if we need to roll forward
         state_est_->addUpdate(update, roll_forward_[sensor_id]);
+#if DEBUG_MODE
         end = std::chrono::high_resolution_clock::now();
         ROS_INFO_STREAM("Time elapsed process addupdate: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
         start = end;
-
+#endif
         if(publish_head_[sensor_id]){
             state_est_->getHeadState(head_state, head_cov);
 
@@ -288,10 +294,12 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
             // publish the pose
             pose_pub_.publish(pose_msg_);
         }
+#if DEBUG_MODE
         end = std::chrono::high_resolution_clock::now();
 
         ROS_INFO_STREAM("Time elapsed till the end: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
         std::cout << std::endl;
+#endif
     }
 }
 

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -7,7 +7,7 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
 #include <tf_conversions/tf_eigen.h>
-
+#include <chrono>
 #include <tf/transform_broadcaster.h>
 
 namespace MavStateEst {
@@ -221,9 +221,9 @@ void ROSFrontEnd::initCallback(boost::shared_ptr<MsgT const> msg, const SensorId
 template <class MsgT>
 void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& sensor_id)
 {
-    if(verbose_){
+    //if(verbose_){
         ROS_INFO_STREAM("Callback for sensor " << sensor_id);
-    }
+    //}
     // this is a generic templated callback that does the same for every module:
     // if the module is initialized and the filter is ready
     // 1) take the measurement update and pass it to the filter if valid
@@ -231,13 +231,25 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
     if(isFilterInitialized()) {
         // appropriate casting to the right type and call to the process message
         // function to get the update
+        // Record start time
+        auto start = std::chrono::high_resolution_clock::now();
         RBISUpdateInterface* update = static_cast<SensingModule<MsgT>*>(active_modules_[sensor_id])->processMessage(msg.get(), state_est_.get());
+        auto end = std::chrono::high_resolution_clock::now();
+
+        ROS_INFO_STREAM("Time elapsed process message: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
+        start = end;
         // if the update is invalid, we leave
         if(update == NULL){
+            std::cout << "Invalid update" << std::endl;
+            std::cout << std::endl;
             return;
         }
         // tell also the filter if we need to roll forward
         state_est_->addUpdate(update, roll_forward_[sensor_id]);
+        end = std::chrono::high_resolution_clock::now();
+        ROS_INFO_STREAM("Time elapsed process addupdate: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
+        start = end;
+
         if(publish_head_[sensor_id]){
             state_est_->getHeadState(head_state, head_cov);
 
@@ -276,7 +288,10 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
             // publish the pose
             pose_pub_.publish(pose_msg_);
         }
+        end = std::chrono::high_resolution_clock::now();
 
+        ROS_INFO_STREAM("Time elapsed till the end: " << std::chrono::duration_cast<std::chrono::microseconds>(end -start).count());
+        std::cout << std::endl;
     }
 }
 

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -102,6 +102,14 @@ InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
                         << "max_initial_gyro_bias\". Using default: "
                         << cfg.max_initial_gyro_bias);
     }
+
+    if(!nh_.getParam(ins_param_prefix + "ignore_accel", cfg.ignore_accel)){
+        ROS_WARN_STREAM("Couldn't get param \""
+                        << nh_.getNamespace()  << "/" << ins_param_prefix
+                        << "ignore_accel\". Using default: "
+                        << std::boolalpha << cfg.ignore_accel << std::noboolalpha);
+    }
+
     if(!nh_.getParam(ins_param_prefix + "topic", imu_topic_)){
         ROS_WARN_STREAM("Couldn't get param \""
                         << nh_.getNamespace()  << "/" << ins_param_prefix


### PR DESCRIPTION
This pull request makes the IMU forward propagation optional for the acceleration. By setting the `ignore_accel` option to true in the config file, the acceleration will not be integrated. If the value is absent, it will behave normally.