### PR TITLE
move all the ROS message conversion into one place

### DIFF
--- a/pronto_ros/CMakeLists.txt
+++ b/pronto_ros/CMakeLists.txt
@@ -106,7 +106,8 @@ add_library(${PROJECT_NAME} src/ins_ros_handler.cpp
                             src/scan_matcher_ros_handler.cpp
                             src/visual_odometry_ros_handler.cpp
                             src/ros_frontend.cpp
-                            src/pose_msg_ros_handler.cpp)
+                            src/pose_msg_ros_handler.cpp
+                            src/pronto_ros_conversions.cpp)
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/pronto_ros/include/pronto_ros/gps_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/gps_ros_handler.hpp
@@ -4,6 +4,8 @@
 #include <pronto_core/sensing_module.hpp>
 #include <pronto_msgs/GPSData.h>
 #include <ros/node_handle.h>
+#include <pronto_ros/pronto_ros_conversions.hpp>
+
 namespace MavStateEst {
 class GPSHandlerROS : public SensingModule<pronto_msgs::GPSData> {
 public:
@@ -22,9 +24,5 @@ protected:
     ros::NodeHandle nh_;
     std::shared_ptr<GPSModule> gps_module_;
     GPSMeasurement gps_meas_;
-
-    void gpsDataFromROS(const pronto_msgs::GPSData& ros_msg,
-                        GPSMeasurement& msg);
-
 };
 } // namespace MavStateEst

--- a/pronto_ros/include/pronto_ros/index_meas_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/index_meas_ros_handler.hpp
@@ -25,9 +25,6 @@ protected:
     IndexedMeasurementModule index_module_;
     IndexedMeasurement index_msg_;
 
-    void indexMeasurementFromROS(const pronto_msgs::IndexedMeasurement& ros_msg,
-                                 IndexedMeasurement& msg);
-
 };
 
 } // namespace MavStateEst

--- a/pronto_ros/include/pronto_ros/ins_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/ins_ros_handler.hpp
@@ -17,9 +17,7 @@ public:
                             const RBIM &default_cov,
                             RBIS &init_state,
                             RBIM &init_cov) override;
-private:
-    void msgToImuMeasurement(const sensor_msgs::Imu& imu_msg,
-                             ImuMeasurement& imu_meas);
+
 
 private:
     ros::NodeHandle& nh_;

--- a/pronto_ros/include/pronto_ros/pose_msg_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/pose_msg_ros_handler.hpp
@@ -22,10 +22,6 @@ private:
     ros::NodeHandle& nh_;
     std::shared_ptr<PoseMeasModule> pose_module_;
     PoseMeasurement pose_meas_;
-
-    void poseMsgFromROS(const geometry_msgs::PoseWithCovarianceStamped& msg,
-                        PoseMeasurement& pose_meas);
-
 };
 
 }

--- a/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
+++ b/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <pronto_core/definitions.hpp>
+
+#include <pronto_msgs/GPSData.h>
+#include <pronto_msgs/IndexedMeasurement.h>
+#include <pronto_msgs/FilterState.h>
+#include <sensor_msgs/Imu.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/TransformStamped.h>
+
+namespace MavStateEst {
+
+void gpsDataFromROS(const pronto_msgs::GPSData& ros_msg,
+                    GPSMeasurement& msg);
+
+void indexMeasurementFromROS(const pronto_msgs::IndexedMeasurement& ros_msg,
+                             IndexedMeasurement& msg);
+
+void filterStateFromROS(const pronto_msgs::FilterState& ros_msg,
+                        FilterState& msg);
+
+void msgToImuMeasurement(const sensor_msgs::Imu& imu_msg,
+                         ImuMeasurement& imu_meas,
+                         const int64_t &utime_offset = 0);
+
+void poseMsgFromROS(const geometry_msgs::PoseWithCovarianceStamped &msg,
+                    PoseMeasurement &pose_meas);
+
+void poseMeasurementFromROS(const nav_msgs::Odometry& ros_msg,
+                            PoseMeasurement& msg);
+
+void rigidTransformFromROS(const geometry_msgs::TransformStamped& msg,
+                           RigidTransform& transf);
+
+}

--- a/pronto_ros/include/pronto_ros/scan_matcher_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/scan_matcher_ros_handler.hpp
@@ -6,6 +6,7 @@
 #include <ros/node_handle.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/LinearMath/Quaternion.h>
+
 namespace  MavStateEst {
 
 class ScanMatcherHandler : SensingModule<nav_msgs::Odometry>{
@@ -27,9 +28,6 @@ protected:
   PoseMeasurement pose_meas_;
   ros::NodeHandle& nh_;
   tf::Quaternion tf_q;
-  void poseMeasurementFromROS(const nav_msgs::Odometry& ros_msg,
-                              PoseMeasurement& msg);
-
 };
 
 

--- a/pronto_ros/include/pronto_ros/vicon_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/vicon_ros_handler.hpp
@@ -25,11 +25,6 @@ private:
     ros::NodeHandle& nh_;
     std::shared_ptr<ViconModule> vicon_module_;
     RigidTransform vicon_transf_;
-    tf::Transform temp_tf_transf_;
-
-
-    void rigidTransformFromROS(const geometry_msgs::TransformStamped& msg,
-                               RigidTransform& transf);
 };
 
 } // namespace MavStateEst

--- a/pronto_ros/src/gps_ros_handler.cpp
+++ b/pronto_ros/src/gps_ros_handler.cpp
@@ -1,4 +1,5 @@
 #include "pronto_ros/gps_ros_handler.hpp"
+#include "pronto_ros/pronto_ros_conversions.hpp"
 
 namespace MavStateEst {
 
@@ -35,21 +36,6 @@ bool GPSHandlerROS::processMessageInit(const pronto_msgs::GPSData *msg,
                                            init_cov);
 }
 
-void GPSHandlerROS::gpsDataFromROS(const pronto_msgs::GPSData &ros_msg,
-                              GPSMeasurement &msg)
-{
-    msg.elev = ros_msg.elev;
-    msg.gps_lock = ros_msg.gps_lock;
-    msg.gps_time = ros_msg.gps_time;
-    msg.heading = ros_msg.heading;
-    msg.horizontal_accuracy = ros_msg.horizontal_accuracy;
-    msg.latitude = ros_msg.latitude;
-    msg.longitude = ros_msg.longitude;
-    msg.numSatellites = ros_msg.num_satellites;
-    msg.speed = ros_msg.speed;
-    msg.utime = ros_msg.utime;
-    msg.vertical_accuracy = ros_msg.vertical_accuracy;
-    msg.xyz_pos = Eigen::Map<const Eigen::Vector3d>(ros_msg.xyz_pos.data());
-}
+
 
 }

--- a/pronto_ros/src/index_meas_ros_handler.cpp
+++ b/pronto_ros/src/index_meas_ros_handler.cpp
@@ -1,4 +1,5 @@
 #include "pronto_ros/index_meas_ros_handler.hpp"
+#include "pronto_ros/pronto_ros_conversions.hpp"
 
 namespace MavStateEst {
 
@@ -30,27 +31,6 @@ bool IndexedMeasurementHandlerROS::processMessageInit(const pronto_msgs::Indexed
                                             init_state,
                                             init_cov);
 }
-
-void IndexedMeasurementHandlerROS::indexMeasurementFromROS(const pronto_msgs::IndexedMeasurement &ros_msg,
-                                                           IndexedMeasurement &msg)
-{
-    // check that the size of z_indices == z_effective and R_effective is its square
-    if(ros_msg.R_effective.size() != ros_msg.z_effective.size() * ros_msg.z_indices.size()){
-        return;
-    }
-
-    // TODO check that the data are rowmajor
-    msg.R_effective = Eigen::Map<const Eigen::MatrixXd>(ros_msg.R_effective.data(),
-                                                        ros_msg.z_effective.size(),
-                                                        ros_msg.z_effective.size());
-    msg.state_utime = ros_msg.state_utime;
-    msg.utime = ros_msg.utime;
-    msg.z_effective = Eigen::Map<const Eigen::VectorXd>(ros_msg.z_effective.data(),
-                                                        ros_msg.z_effective.size());
-    msg.z_indices = Eigen::Map<const Eigen::VectorXi>(ros_msg.z_indices.data(),
-                                                      ros_msg.z_indices.size());
-}
-
 } // namespace MavStateEst
 
 

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -1,6 +1,10 @@
 #include "pronto_ros/ins_ros_handler.hpp"
 #include <eigen_conversions/eigen_msg.h>
 #include <tf/transform_listener.h>
+
+#include "pronto_ros/pronto_ros_conversions.hpp"
+
+
 namespace MavStateEst {
 
 InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
@@ -186,16 +190,8 @@ RBISUpdateInterface* InsHandlerROS::processMessage(const sensor_msgs::Imu *imu_m
     if(counter++ % downsample_factor_ != 0){
         return NULL;
     }
-    msgToImuMeasurement(*imu_msg, imu_meas_);
+    msgToImuMeasurement(*imu_msg, imu_meas_, utime_offset_);
     return ins_module_.processMessage(&imu_meas_, est);
-}
-
-void InsHandlerROS::msgToImuMeasurement(const sensor_msgs::Imu &imu_msg, ImuMeasurement &imu_meas){
-    // convert the ROS message into our internal format
-    tf::vectorMsgToEigen(imu_msg.linear_acceleration,imu_meas.acceleration);
-    tf::quaternionMsgToEigen(imu_msg.orientation, imu_meas.orientation);
-    tf::vectorMsgToEigen(imu_msg.angular_velocity, imu_meas.omega);
-    imu_meas.utime = imu_msg.header.stamp.toNSec() / 1000 + utime_offset_;
 }
 
 bool InsHandlerROS::processMessageInit(const sensor_msgs::Imu *imu_msg,

--- a/pronto_ros/src/pose_msg_ros_handler.cpp
+++ b/pronto_ros/src/pose_msg_ros_handler.cpp
@@ -1,5 +1,5 @@
 #include "pronto_ros/pose_msg_ros_handler.hpp"
-
+#include "pronto_ros/pronto_ros_conversions.hpp"
 
 namespace MavStateEst {
 
@@ -57,20 +57,4 @@ bool PoseHandlerROS::processMessageInit(const geometry_msgs::PoseWithCovarianceS
                                             init_state,
                                             init_cov);
 }
-
-
-void PoseHandlerROS::poseMsgFromROS(const geometry_msgs::PoseWithCovarianceStamped &msg,
-                               PoseMeasurement &pose_meas)
-{
-    pose_meas.orientation = Orientation(msg.pose.pose.orientation.w,
-                                        msg.pose.pose.orientation.x,
-                                        msg.pose.pose.orientation.y,
-                                        msg.pose.pose.orientation.z);
-    pose_meas.pos << msg.pose.pose.position.x,
-                     msg.pose.pose.position.y,
-                     msg.pose.pose.position.z;
-    pose_meas.utime = (uint64_t) msg.header.stamp.toNSec() / 1000;
-}
-
-
 }

--- a/pronto_ros/src/pronto_ros_conversions.cpp
+++ b/pronto_ros/src/pronto_ros_conversions.cpp
@@ -1,0 +1,115 @@
+#include "pronto_ros/pronto_ros_conversions.hpp"
+#include <tf_conversions/tf_eigen.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace MavStateEst {
+
+void gpsDataFromROS(const pronto_msgs::GPSData &ros_msg,
+                    GPSMeasurement &msg)
+{
+    msg.elev = ros_msg.elev;
+    msg.gps_lock = ros_msg.gps_lock;
+    msg.gps_time = ros_msg.gps_time;
+    msg.heading = ros_msg.heading;
+    msg.horizontal_accuracy = ros_msg.horizontal_accuracy;
+    msg.latitude = ros_msg.latitude;
+    msg.longitude = ros_msg.longitude;
+    msg.numSatellites = ros_msg.num_satellites;
+    msg.speed = ros_msg.speed;
+    msg.utime = ros_msg.utime;
+    msg.vertical_accuracy = ros_msg.vertical_accuracy;
+    msg.xyz_pos = Eigen::Map<const Eigen::Vector3d>(ros_msg.xyz_pos.data());
+}
+
+void indexMeasurementFromROS(const pronto_msgs::IndexedMeasurement &ros_msg,
+                                                           IndexedMeasurement &msg)
+{
+    // check that the size of z_indices == z_effective and R_effective is its square
+    if(ros_msg.R_effective.size() != ros_msg.z_effective.size() * ros_msg.z_indices.size()){
+        return;
+    }
+
+    // TODO check that the data are rowmajor
+    msg.R_effective = Eigen::Map<const Eigen::MatrixXd>(ros_msg.R_effective.data(),
+                                                        ros_msg.z_effective.size(),
+                                                        ros_msg.z_effective.size());
+    msg.state_utime = ros_msg.state_utime;
+    msg.utime = ros_msg.utime;
+    msg.z_effective = Eigen::Map<const Eigen::VectorXd>(ros_msg.z_effective.data(),
+                                                        ros_msg.z_effective.size());
+    msg.z_indices = Eigen::Map<const Eigen::VectorXi>(ros_msg.z_indices.data(),
+                                                      ros_msg.z_indices.size());
+}
+
+void filterStateFromROS(const pronto_msgs::FilterState &ros_msg,
+                        FilterState &msg)
+{
+    if(ros_msg.cov.size() != std::pow(ros_msg.state.size(),2))
+    {
+        throw std::logic_error("Covariance matrix of size " +
+                               std::to_string(ros_msg.cov.size()) +
+        + ". " + std::to_string(std::pow(ros_msg.state.size(),2)) + " expected.");
+        return;
+    }
+    Eigen::Quaterniond init_quat;
+    tf::Quaternion q;
+    tf::quaternionMsgToTF(ros_msg.quat, q);
+    tf::quaternionTFToEigen(q, init_quat);
+    Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> cov_map(ros_msg.cov.data(),
+                                                                         ros_msg.state.size(),
+                                                                         ros_msg.state.size());
+    msg.cov = cov_map;
+    msg.quat = init_quat;
+    msg.state = Eigen::Map<const Eigen::VectorXd>(ros_msg.state.data(), ros_msg.state.size());
+    msg.utime = ros_msg.header.stamp.toNSec() / 1000;
+}
+
+void msgToImuMeasurement(const sensor_msgs::Imu &imu_msg,
+                         ImuMeasurement &imu_meas,
+                         const int64_t& utime_offset)
+{
+    // convert the ROS message into our internal format
+    tf::vectorMsgToEigen(imu_msg.linear_acceleration,imu_meas.acceleration);
+    tf::quaternionMsgToEigen(imu_msg.orientation, imu_meas.orientation);
+    tf::vectorMsgToEigen(imu_msg.angular_velocity, imu_meas.omega);
+    imu_meas.utime = imu_msg.header.stamp.toNSec() / 1000 + utime_offset;
+}
+
+void poseMsgFromROS(const geometry_msgs::PoseWithCovarianceStamped &msg,
+                    PoseMeasurement &pose_meas)
+{
+    pose_meas.orientation = Orientation(msg.pose.pose.orientation.w,
+                                        msg.pose.pose.orientation.x,
+                                        msg.pose.pose.orientation.y,
+                                        msg.pose.pose.orientation.z);
+    pose_meas.pos << msg.pose.pose.position.x,
+                     msg.pose.pose.position.y,
+                     msg.pose.pose.position.z;
+    pose_meas.utime = (uint64_t) msg.header.stamp.toNSec() / 1000;
+}
+
+void poseMeasurementFromROS(const nav_msgs::Odometry &ros_msg,
+                            PoseMeasurement &msg)
+{
+    msg.utime = ros_msg.header.stamp.toNSec() / 1000;
+    msg.linear_vel << ros_msg.twist.twist.linear.x,
+            ros_msg.twist.twist.linear.y,
+            ros_msg.twist.twist.linear.z;
+
+    msg.pos << ros_msg.pose.pose.position.x,
+            ros_msg.pose.pose.position.y,
+            ros_msg.pose.pose.position.z;
+    tf::Quaternion tf_q;
+    tf::quaternionMsgToTF(ros_msg.pose.pose.orientation, tf_q);
+    tf::quaternionTFToEigen(tf_q, msg.orientation);
+}
+
+void rigidTransformFromROS(const geometry_msgs::TransformStamped &msg,
+                           RigidTransform &transf)
+{
+    tf::Transform temp_tf_transf_;
+    tf::transformMsgToTF(msg.transform, temp_tf_transf_);
+    tf::transformTFToEigen(temp_tf_transf_, transf.transform);
+    transf.utime = msg.header.stamp.toNSec() / 1000; // from nanosec to microsec
+}
+}

--- a/pronto_ros/src/scan_matcher_ros_handler.cpp
+++ b/pronto_ros/src/scan_matcher_ros_handler.cpp
@@ -1,6 +1,7 @@
 #include "pronto_ros/scan_matcher_ros_handler.hpp"
 #include <string>
 #include <tf_conversions/tf_eigen.h>
+#include "pronto_ros/pronto_ros_conversions.hpp"
 
 namespace MavStateEst {
 
@@ -115,19 +116,8 @@ ScanMatcherHandler::ScanMatcherHandler(ros::NodeHandle& nh) : nh_(nh)
 RBISUpdateInterface * ScanMatcherHandler::processMessage(const nav_msgs::Odometry * msg,
                                                          MavStateEstimator* state_estimator)
 {
-    // convert LCM to generic format
-    pose_meas_.utime = msg->header.stamp.toNSec() / 1000;
-    pose_meas_.linear_vel << msg->twist.twist.linear.x,
-                             msg->twist.twist.linear.y,
-                             msg->twist.twist.linear.z;
-
-    pose_meas_.pos << msg->pose.pose.position.x,
-                      msg->pose.pose.position.y,
-                      msg->pose.pose.position.z;
-    tf::Quaternion tf_q;
-    tf::quaternionMsgToTF(msg->pose.pose.orientation, tf_q);
-    tf::quaternionTFToEigen(tf_q, pose_meas_.orientation);
-    return scan_matcher_module_.processMessage(&pose_meas_,state_estimator);
+    poseMeasurementFromROS(*msg, pose_meas_);
+    return scan_matcher_module_.processMessage(&pose_meas_, state_estimator);
 }
 
 bool ScanMatcherHandler::processMessageInit(const nav_msgs::Odometry *msg,

--- a/pronto_ros/src/vicon_ros_handler.cpp
+++ b/pronto_ros/src/vicon_ros_handler.cpp
@@ -1,8 +1,9 @@
 #include "pronto_ros/vicon_ros_handler.hpp"
+#include "pronto_ros/pronto_ros_conversions.hpp"
 #include <tf/transform_listener.h>
-#include <tf_conversions/tf_eigen.h>
 
 namespace MavStateEst {
+
 ViconHandlerROS::ViconHandlerROS(ros::NodeHandle &nh) :
 nh_(nh)
 {
@@ -87,13 +88,4 @@ bool ViconHandlerROS::processMessageInit(const geometry_msgs::TransformStamped *
                                              init_state,
                                              init_cov);
 }
-
-void ViconHandlerROS::rigidTransformFromROS(const geometry_msgs::TransformStamped &msg,
-                                            RigidTransform &transf)
-{
-    tf::transformMsgToTF(msg.transform, temp_tf_transf_);
-    tf::transformTFToEigen(temp_tf_transf_, transf.transform);
-    transf.utime = msg.header.stamp.toNSec() / 1000; // from nanosec to microsec
-}
-
 } // namespace MavStateEst


### PR DESCRIPTION
This PR moves all the message conversion implemented inside the handlers into one place. So if multiple handlers have to convert the same ROS message they don't have to implement their own conversion.