### PR TITLE
Namespace refactoring

### DIFF
--- a/pronto_core/CMakeLists.txt
+++ b/pronto_core/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library (${PRONTO_CORE_LIB} src/rbis.cpp
                                 src/ins_module.cpp
                                 src/scan_matcher_module.cpp
                                 src/rbis_update_interface.cpp
-                                src/mav_state_est.cpp
+                                src/state_est.cpp
                                 src/update_history.cpp
                                 src/visual_odometry_module.cpp
                                 src/vicon_module.cpp

--- a/pronto_core/include/pronto_core/definitions.hpp
+++ b/pronto_core/include/pronto_core/definitions.hpp
@@ -3,7 +3,7 @@
 #include <Eigen/Dense>
 #include <vector>
 
-namespace MavStateEst {
+namespace pronto {
 
 typedef Eigen::Vector3d Position;
 typedef Eigen::Quaterniond Orientation;

--- a/pronto_core/include/pronto_core/gps_module.hpp
+++ b/pronto_core/include/pronto_core/gps_module.hpp
@@ -2,7 +2,7 @@
 #include "pronto_core/definitions.hpp"
 #include "pronto_core/sensing_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 struct GPSConfig{
     double r_gps_xy;
@@ -15,7 +15,7 @@ public:
 public:
     GPSModule(const GPSConfig& cfg);
     RBISUpdateInterface* processMessage(const GPSMeasurement *msg,
-                                        MavStateEstimator *est) override;
+                                        StateEstimator *est) override;
     bool processMessageInit(const GPSMeasurement *msg,
                             const std::map<std::string, bool> &sensor_initialized,
                             const RBIS &default_state,
@@ -30,4 +30,4 @@ protected:
 
 };
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_core/include/pronto_core/indexed_meas_module.hpp
+++ b/pronto_core/include/pronto_core/indexed_meas_module.hpp
@@ -1,12 +1,12 @@
 #pragma once
 #include "pronto_core/definitions.hpp"
 #include "pronto_core/sensing_module.hpp"
-namespace MavStateEst {
+namespace pronto {
 
 class IndexedMeasurementModule : public SensingModule<IndexedMeasurement> {
 public:
     IndexedMeasurementModule(const RBISUpdateInterface::sensor_enum& sensor);
-    RBISUpdateInterface* processMessage(const IndexedMeasurement *msg, MavStateEstimator *est) override;
+    RBISUpdateInterface* processMessage(const IndexedMeasurement *msg, StateEstimator *est) override;
 
     bool processMessageInit(const IndexedMeasurement *msg,
                             const std::map<std::string, bool> &sensor_initialized,
@@ -19,4 +19,4 @@ protected:
 
 };
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_core/include/pronto_core/init_message_module.hpp
+++ b/pronto_core/include/pronto_core/init_message_module.hpp
@@ -3,12 +3,12 @@
 #include "pronto_core/sensing_module.hpp"
 #include "pronto_core/definitions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 class InitMessageModule : public SensingModule<FilterState> {
 public:
 
     RBISUpdateInterface* processMessage(const FilterState *msg,
-                                        MavStateEstimator *est) override;
+                                        StateEstimator *est) override;
 
     bool processMessageInit(const FilterState *msg,
                             const std::map<std::string, bool> &sensor_initialized,
@@ -19,5 +19,5 @@ public:
 
 
 };
-} // namespace MavStateEst
+} // namespace pronto
 

--- a/pronto_core/include/pronto_core/ins_module.hpp
+++ b/pronto_core/include/pronto_core/ins_module.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "pronto_core/definitions.hpp"
 #include "pronto_core/sensing_module.hpp"
-namespace MavStateEst {
+namespace pronto {
 
 struct InsConfig {
 public:
@@ -40,7 +40,7 @@ public:
     ~InsModule();
 
   RBISUpdateInterface * processMessage(const ImuMeasurement *msg,
-                                       MavStateEstimator* state_estimator) override;
+                                       StateEstimator* state_estimator) override;
 
   bool processMessageInit(const ImuMeasurement * msg,
                           const std::map<std::string, bool> & sensors_initialized,

--- a/pronto_core/include/pronto_core/pose_meas_module.hpp
+++ b/pronto_core/include/pronto_core/pose_meas_module.hpp
@@ -3,7 +3,7 @@
 #include "pronto_core/sensing_module.hpp"
 #include "pronto_core/definitions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 enum class PoseMeasMode { MODE_POSITION = 0, MODE_POSITION_ORIENT };
 
@@ -26,7 +26,7 @@ public:
     PoseMeasModule(const PoseMeasConfig& cfg);
 
     RBISUpdateInterface* processMessage(const PoseMeasurement *msg,
-                                        MavStateEstimator *est);
+                                        StateEstimator *est);
 
     bool processMessageInit(const PoseMeasurement *msg,
                             const std::map<std::string, bool> &sensor_initialized,
@@ -42,5 +42,5 @@ protected:
   MeasVector z_meas;
   MeasCovMatrix cov_pose_meas;
 };
-} // namespace MavStateEst
+} // namespace pronto
 

--- a/pronto_core/include/pronto_core/rbis.hpp
+++ b/pronto_core/include/pronto_core/rbis.hpp
@@ -5,7 +5,7 @@
 #include <Eigen/Geometry>
 #include <eigen_utils/eigen_utils.hpp>
 
-namespace MavStateEst {
+namespace pronto {
 
 /**
  * Rigid body state

--- a/pronto_core/include/pronto_core/rbis_update_interface.hpp
+++ b/pronto_core/include/pronto_core/rbis_update_interface.hpp
@@ -3,7 +3,7 @@
 
 #include "rbis.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 class RBISUpdateInterface {
 public:

--- a/pronto_core/include/pronto_core/scan_matcher_module.hpp
+++ b/pronto_core/include/pronto_core/scan_matcher_module.hpp
@@ -3,9 +3,9 @@
 #include "pronto_core/rbis_update_interface.hpp"
 #include "pronto_core/definitions.hpp"
 #include "pronto_core/sensing_module.hpp"
-#include "pronto_core/mav_state_est.hpp"
+#include "pronto_core/state_est.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 //enum ScanMatchingMode {
 //    MODE_POSITION, MODE_POSITION_YAW, MODE_VELOCITY, MODE_VELOCITY_YAW, MODE_YAW
@@ -25,7 +25,7 @@ public:
                     const Eigen::MatrixXd& cov_scan_match);
 
   RBISUpdateInterface * processMessage(const PoseMeasurement * msg,
-                                       MavStateEstimator* state_estimator) override;
+                                       StateEstimator* state_estimator) override;
 
   bool processMessageInit(const PoseMeasurement *msg,
                           const std::map<std::string, bool> &sensor_initialized,

--- a/pronto_core/include/pronto_core/sensing_module.hpp
+++ b/pronto_core/include/pronto_core/sensing_module.hpp
@@ -1,15 +1,15 @@
 #pragma once
 #include "pronto_core/rbis_update_interface.hpp"
-#include "pronto_core/mav_state_est.hpp"
+#include "pronto_core/state_est.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 template <class MessageT>
 class SensingModule {
 public:
     virtual ~SensingModule() {}
 
     virtual RBISUpdateInterface* processMessage(const MessageT* msg,
-                                                MavStateEstimator* est = NULL) = 0;
+                                                StateEstimator* est = NULL) = 0;
 
     virtual bool processMessageInit(const MessageT* msg,
                                     const std::map<std::string,bool>& sensor_initialized,

--- a/pronto_core/include/pronto_core/state_est.hpp
+++ b/pronto_core/include/pronto_core/state_est.hpp
@@ -4,16 +4,16 @@
 #include "rbis.hpp"
 #include "update_history.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
-class MavStateEstimator {
+class StateEstimator {
 public:
     typedef Eigen::Vector3d Vector3d;
     typedef Eigen::Quaterniond Quaterniond;
 public:
-  MavStateEstimator(RBISResetUpdate * init_state,
+  StateEstimator(RBISResetUpdate * init_state,
                     const uint64_t& history_span);
-  ~MavStateEstimator();
+  ~StateEstimator();
 
   updateHistory::historyMapIterator unprocessed_updates_start;
   updateHistory history;

--- a/pronto_core/include/pronto_core/update_history.hpp
+++ b/pronto_core/include/pronto_core/update_history.hpp
@@ -7,7 +7,7 @@
 
 #include "rbis_update_interface.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 class updateHistory {
 public:

--- a/pronto_core/include/pronto_core/vicon_module.hpp
+++ b/pronto_core/include/pronto_core/vicon_module.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "pronto_core/sensing_module.hpp"
 #include "pronto_core/definitions.hpp"
-namespace MavStateEst {
+namespace pronto {
 
 enum class ViconMode {MODE_POSITION,
                       MODE_POSITION_ORIENT,
@@ -34,7 +34,7 @@ public:
     ViconModule(const ViconConfig& cfg);
 
     RBISUpdateInterface* processMessage(const RigidTransform *msg,
-                                        MavStateEstimator *est) override;
+                                        StateEstimator *est) override;
 
     bool processMessageInit(const RigidTransform *msg,
                             const std::map<std::string, bool> &sensor_initialized,

--- a/pronto_core/include/pronto_core/visual_odometry_module.hpp
+++ b/pronto_core/include/pronto_core/visual_odometry_module.hpp
@@ -2,7 +2,7 @@
 #include "pronto_core/sensing_module.hpp"
 #include "pronto_core/definitions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 enum class VisualOdometryMode {MODE_VELOCITY,
                                MODE_ROTATION_RATE,
@@ -31,7 +31,7 @@ public:
     VisualOdometryModule(const VisualOdometryConfig& cfg);
 
     RBISUpdateInterface* processMessage(const VisualOdometryUpdate *msg,
-                                        MavStateEstimator *est) override;
+                                        StateEstimator *est) override;
 
     bool processMessageInit(const VisualOdometryUpdate *msg,
                             const std::map<std::string, bool> &sensor_initialized,

--- a/pronto_core/src/gps_module.cpp
+++ b/pronto_core/src/gps_module.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/gps_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 GPSModule::GPSModule(const GPSConfig &cfg){
     Eigen::Vector3d R_gps_diagonal = Eigen::Array3d(cfg.r_gps_xy, cfg.r_gps_xy, cfg.r_gps_z).pow(2);
@@ -8,7 +8,7 @@ GPSModule::GPSModule(const GPSConfig &cfg){
 }
 
 RBISUpdateInterface* GPSModule::processMessage(const GPSMeasurement *msg,
-                                               MavStateEstimator *est)
+                                               StateEstimator *est)
 {
     if (msg->gps_lock < 3) {
       return NULL;
@@ -45,4 +45,4 @@ bool GPSModule::processMessageInit(const GPSMeasurement *msg,
     return true;
 }
 
-} // namespace MavStateEst 
+} // namespace pronto 

--- a/pronto_core/src/indexed_meas_module.cpp
+++ b/pronto_core/src/indexed_meas_module.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/indexed_meas_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 IndexedMeasurementModule::IndexedMeasurementModule(const RBISUpdateInterface::sensor_enum& sensor) :
     indexed_sensor(sensor){
@@ -8,7 +8,7 @@ IndexedMeasurementModule::IndexedMeasurementModule(const RBISUpdateInterface::se
 }
 
 RBISUpdateInterface* IndexedMeasurementModule::processMessage(const IndexedMeasurement *msg,
-                                         MavStateEstimator *est)
+                                         StateEstimator *est)
 {
     return new RBISIndexedMeasurement(msg->z_indices,
                                       msg->z_effective,
@@ -48,4 +48,4 @@ bool IndexedMeasurementModule::processMessageInit(const IndexedMeasurement *msg,
 }
 
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_core/src/init_message_module.cpp
+++ b/pronto_core/src/init_message_module.cpp
@@ -1,9 +1,9 @@
 #include "pronto_core/init_message_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 RBISUpdateInterface* InitMessageModule::processMessage(const FilterState *msg,
-                                                       MavStateEstimator *est)
+                                                       StateEstimator *est)
 {
     RBIS state = RBIS(msg->state, msg->quat);
     state.utime = msg->utime;
@@ -28,5 +28,5 @@ bool InitMessageModule::processMessageInit(const FilterState *msg,
     return true;
 }
 
-} // namespace MavStateEst
+} // namespace pronto
 

--- a/pronto_core/src/ins_module.cpp
+++ b/pronto_core/src/ins_module.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/ins_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 InsModule::InsModule() : InsModule(InsConfig(), Eigen::Affine3d::Identity())
 {
@@ -47,7 +47,7 @@ bool InsModule::allInitializedExcept(const std::map<std::string, bool> &_sensors
 }
 
 RBISUpdateInterface * InsModule::processMessage(const ImuMeasurement * msg,
-                                                 MavStateEstimator* state_estimator)
+                                                 StateEstimator* state_estimator)
 {
 
   Eigen::Vector3d accelerometer(ins_to_body.rotation() * msg->acceleration);

--- a/pronto_core/src/pose_meas_module.cpp
+++ b/pronto_core/src/pose_meas_module.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/pose_meas_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 PoseMeasModule::PoseMeasModule(const PoseMeasConfig &cfg) :
     mode(cfg.mode), no_corrections(cfg.number_of_corrections)
@@ -23,7 +23,7 @@ PoseMeasModule::PoseMeasModule(const PoseMeasConfig &cfg) :
 }
 
 RBISUpdateInterface* PoseMeasModule::processMessage(const PoseMeasurement *msg,
-                                                    MavStateEstimator *est)
+                                                    StateEstimator *est)
 {
     // If we have created no_corrections, go silent afterwards
     no_corrections--;
@@ -90,5 +90,5 @@ bool PoseMeasModule::processMessageInit(const PoseMeasurement *msg,
 
     return true;
 }
-} // namespace MavStateEst
+} // namespace pronto
 

--- a/pronto_core/src/rbis.cpp
+++ b/pronto_core/src/rbis.cpp
@@ -5,7 +5,7 @@ using namespace eigen_utils;
 using namespace Eigen;
 using namespace std;
 
-namespace MavStateEst {
+namespace pronto {
 
 typedef Eigen::Matrix<double, 12, 1> Vector12d;
 typedef Eigen::Matrix<double, 12, 12> Matrix12d;

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/rbis_update_interface.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 const char * RBISUpdateInterface::sensor_enum_chars = "igvlfsorxdukpabmtwy";
 const char * RBISUpdateInterface::sensor_enum_strings[] =

--- a/pronto_core/src/scan_matcher_module.cpp
+++ b/pronto_core/src/scan_matcher_module.cpp
@@ -1,7 +1,7 @@
 #include "pronto_core/scan_matcher_module.hpp"
 #include "eigen_utils/eigen_rigidbody.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 // using MODE_POSITION     = ScanMatchingMode::MODE_POSITION;
 // using MODE_POSITION_YAW = ScanMatchingMode::MODE_POSITION_YAW;
@@ -27,7 +27,7 @@ ScanMatcherModule::ScanMatcherModule(const ScanMatchingMode &mode,
 }
 
 RBISUpdateInterface * ScanMatcherModule::processMessage(const PoseMeasurement *msg,
-                                                        MavStateEstimator *state_estimator)
+                                                        StateEstimator *state_estimator)
 {
     if (mode == MODE_POSITION) {
       return new RBISIndexedMeasurement(eigen_utils::RigidBodyState::positionInds(),

--- a/pronto_core/src/update_history.cpp
+++ b/pronto_core/src/update_history.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/update_history.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 updateHistory::updateHistory(RBISUpdateInterface * init)
 {

--- a/pronto_core/src/vicon_module.cpp
+++ b/pronto_core/src/vicon_module.cpp
@@ -1,6 +1,6 @@
 #include "pronto_core/vicon_module.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 ViconModule::ViconModule(const ViconConfig &cfg) :
     mode(cfg.mode),
@@ -45,7 +45,7 @@ ViconModule::ViconModule(const ViconConfig &cfg) :
 }
 
 RBISUpdateInterface* ViconModule::processMessage(const RigidTransform *msg,
-                                                 MavStateEstimator *est)
+                                                 StateEstimator *est)
 {
     local_to_vicon = msg->transform;
     // TODO check that this is correct
@@ -122,6 +122,6 @@ bool ViconModule::processMessageInit(const RigidTransform *msg,
     return true;
 }
 
-}// namespace MavStateEst
+}// namespace pronto
 
 

--- a/pronto_core/src/visual_odometry_module.cpp
+++ b/pronto_core/src/visual_odometry_module.cpp
@@ -1,8 +1,8 @@
 #include "pronto_core/visual_odometry_module.hpp"
 
-using Update = MavStateEst::RBISUpdateInterface;
+using Update = pronto::RBISUpdateInterface;
 using namespace std;
-namespace MavStateEst {
+namespace pronto {
 
 VisualOdometryModule::VisualOdometryModule(const VisualOdometryConfig &cfg) :
     mode_(cfg.mode), z_indices(cfg.z_indices), cov_vo_(cfg.cov_vo)
@@ -11,7 +11,7 @@ VisualOdometryModule::VisualOdometryModule(const VisualOdometryConfig &cfg) :
 }
 
 Update* VisualOdometryModule::processMessage(const VisualOdometryUpdate *msg,
-                                             MavStateEstimator *est)
+                                             StateEstimator *est)
 {
     // TODO more appropriate check to distinguish different situations
     if(msg->status != VisualOdometryUpdate::ESTIMATE_VALID){

--- a/pronto_core/test/imu_module_test.cpp
+++ b/pronto_core/test/imu_module_test.cpp
@@ -3,7 +3,7 @@
 #include <chrono>
 
 #include <gtest/gtest.h>
-using namespace MavStateEst;
+using namespace pronto;
 
 TEST(InsModule, ballisticTrajectory) {
 
@@ -76,9 +76,9 @@ TEST(InsModule, ballisticTrajectory) {
     init_state.position() << 0, 0, 19.62;
 
 
-    MavStateEstimator state_estimator(new RBISResetUpdate(init_state,
+    StateEstimator state_estimator(new RBISResetUpdate(init_state,
                                                           init_covariance,
-                                                          MavStateEst::RBISUpdateInterface::reset,
+                                                          pronto::RBISUpdateInterface::reset,
                                                           init_state.utime),
                                       history_span);
 

--- a/pronto_ros/include/pronto_ros/gps_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/gps_ros_handler.hpp
@@ -6,12 +6,12 @@
 #include <ros/node_handle.h>
 #include <pronto_ros/pronto_ros_conversions.hpp>
 
-namespace MavStateEst {
+namespace pronto {
 class GPSHandlerROS : public SensingModule<pronto_msgs::GPSData> {
 public:
     GPSHandlerROS(ros::NodeHandle& nh);
     RBISUpdateInterface* processMessage(const pronto_msgs::GPSData *msg,
-                                        MavStateEstimator *est) override;
+                                        StateEstimator *est) override;
 
     bool processMessageInit(const pronto_msgs::GPSData *msg,
                             const std::map<std::string, bool> &sensor_initialized,
@@ -25,4 +25,4 @@ protected:
     std::shared_ptr<GPSModule> gps_module_;
     GPSMeasurement gps_meas_;
 };
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/include/pronto_ros/index_meas_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/index_meas_ros_handler.hpp
@@ -4,7 +4,7 @@
 #include <pronto_msgs/IndexedMeasurement.h>
 
 
-namespace MavStateEst {
+namespace pronto {
 
 class IndexedMeasurementHandlerROS : public SensingModule<pronto_msgs::IndexedMeasurement>
 {
@@ -12,7 +12,7 @@ public:
     IndexedMeasurementHandlerROS(const RBISUpdateInterface::sensor_enum& this_sensor);
 
     RBISUpdateInterface * processMessage(const pronto_msgs::IndexedMeasurement *msg,
-                                         MavStateEstimator* state_estimator);
+                                         StateEstimator* state_estimator);
 
     bool processMessageInit(const pronto_msgs::IndexedMeasurement *msg,
                             const std::map<std::string, bool> & sensors_initialized,
@@ -27,4 +27,4 @@ protected:
 
 };
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/include/pronto_ros/init_message_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/init_message_ros_handler.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <pronto_core/rbis_update_interface.hpp>
-#include <pronto_core/mav_state_est.hpp>
+#include <pronto_core/state_est.hpp>
 #include <pronto_core/init_message_module.hpp>
 #include <pronto_msgs/FilterState.h>
 #include <map>
 
-namespace MavStateEst {
+namespace pronto {
 
 class InitMessageHandlerROS : public SensingModule<pronto_msgs::FilterState>{
 public:
@@ -16,7 +16,7 @@ public:
                           RBIS & init_state, RBIM & init_cov);
 
   RBISUpdateInterface * processMessage(const pronto_msgs::FilterState * msg,
-                                       MavStateEstimator* state_estimator);
+                                       StateEstimator* state_estimator);
 protected:
   InitMessageModule init_module_;
   FilterState init_msg_;

--- a/pronto_ros/include/pronto_ros/ins_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/ins_ros_handler.hpp
@@ -4,12 +4,12 @@
 #include <ros/node_handle.h>
 #include <pronto_core/ins_module.hpp>
 
-namespace MavStateEst {
+namespace pronto {
 class InsHandlerROS : public SensingModule<sensor_msgs::Imu> {
 public:
     InsHandlerROS(ros::NodeHandle& nh);
 
-    RBISUpdateInterface* processMessage(const sensor_msgs::Imu *imu_msg, MavStateEstimator *est) override;
+    RBISUpdateInterface* processMessage(const sensor_msgs::Imu *imu_msg, StateEstimator *est) override;
 
     bool processMessageInit(const sensor_msgs::Imu *imu_msg,
                             const std::map<std::string, bool> &sensor_initialized,

--- a/pronto_ros/include/pronto_ros/pose_msg_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/pose_msg_ros_handler.hpp
@@ -3,14 +3,14 @@
 #include <pronto_core/pose_meas_module.hpp>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 
-namespace MavStateEst {
+namespace pronto {
 
 class PoseHandlerROS : public SensingModule<geometry_msgs::PoseWithCovarianceStamped> {
 public:
     PoseHandlerROS(ros::NodeHandle& nh);
 
     RBISUpdateInterface* processMessage(const geometry_msgs::PoseWithCovarianceStamped *msg,
-                                        MavStateEstimator *est);
+                                        StateEstimator *est);
 
     bool processMessageInit(const geometry_msgs::PoseWithCovarianceStamped *msg,
                             const std::map<std::string, bool> &sensor_initialized,

--- a/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
+++ b/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
@@ -9,7 +9,7 @@
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/TransformStamped.h>
 
-namespace MavStateEst {
+namespace pronto {
 
 void gpsDataFromROS(const pronto_msgs::GPSData& ros_msg,
                     GPSMeasurement& msg);

--- a/pronto_ros/include/pronto_ros/ros_frontend.hpp
+++ b/pronto_ros/include/pronto_ros/ros_frontend.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <pronto_core/sensing_module.hpp>
-#include <pronto_core/mav_state_est.hpp>
+#include <pronto_core/state_est.hpp>
 #include <ros/node_handle.h>
 #include <sensor_msgs/Imu.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -10,7 +10,7 @@
 #include <chrono>
 #include <tf/transform_broadcaster.h>
 
-namespace MavStateEst {
+namespace pronto {
 class ROSFrontEnd {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -42,7 +42,7 @@ public:
     }
 
     inline bool reset(const RBIS& state, const RBIM& cov) {
-        state_est_->addUpdate(new MavStateEst::RBISResetUpdate(state,
+        state_est_->addUpdate(new pronto::RBISResetUpdate(state,
                                                                cov,
                                                                RBISUpdateInterface::reset,
                                                                state.utime), true);
@@ -63,7 +63,7 @@ protected:
 
 private:
     ros::NodeHandle& nh_;
-    std::shared_ptr<MavStateEstimator> state_est_;
+    std::shared_ptr<StateEstimator> state_est_;
     std::map<SensorId, ros::Subscriber> sensors_subscribers_;
     std::map<SensorId, ros::Subscriber> init_subscribers_;
     std::map<SensorId, void*> active_modules_;
@@ -102,7 +102,7 @@ private:
 };
 }
 
-namespace MavStateEst {
+namespace pronto {
 
 
 template <class MsgT>
@@ -303,4 +303,4 @@ void ROSFrontEnd::callback(boost::shared_ptr<MsgT const> msg, const SensorId& se
     }
 }
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/include/pronto_ros/scan_matcher_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/scan_matcher_ros_handler.hpp
@@ -1,20 +1,20 @@
 #pragma once
 #include <Eigen/Dense>
 #include <pronto_core/rbis_update_interface.hpp>
-#include <pronto_core/mav_state_est.hpp>
+#include <pronto_core/state_est.hpp>
 #include <pronto_core/scan_matcher_module.hpp>
 #include <ros/node_handle.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/LinearMath/Quaternion.h>
 
-namespace  MavStateEst {
+namespace pronto {
 
 class ScanMatcherHandler : SensingModule<nav_msgs::Odometry>{
 public:
   ScanMatcherHandler(ros::NodeHandle& nh);
 
   RBISUpdateInterface * processMessage(const nav_msgs::Odometry * msg,
-                                       MavStateEstimator* state_estimator) override;
+                                       StateEstimator* state_estimator) override;
 
   bool processMessageInit(const nav_msgs::Odometry *msg,
                           const std::map<std::string, bool> &sensor_initialized,
@@ -31,4 +31,4 @@ protected:
 };
 
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/include/pronto_ros/vicon_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/vicon_ros_handler.hpp
@@ -4,14 +4,14 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <tf_conversions/tf_eigen.h>
 
-namespace MavStateEst {
+namespace pronto {
 
 class ViconHandlerROS : public SensingModule<geometry_msgs::TransformStamped> {
 public:
     ViconHandlerROS(ros::NodeHandle& nh);
 
     RBISUpdateInterface* processMessage(const geometry_msgs::TransformStamped *msg,
-                                        MavStateEstimator *est);
+                                        StateEstimator *est);
 
     bool processMessageInit(const geometry_msgs::TransformStamped *msg,
                             const std::map<std::string, bool> &sensor_initialized,
@@ -27,4 +27,4 @@ private:
     RigidTransform vicon_transf_;
 };
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/src/gps_ros_handler.cpp
+++ b/pronto_ros/src/gps_ros_handler.cpp
@@ -1,7 +1,7 @@
 #include "pronto_ros/gps_ros_handler.hpp"
 #include "pronto_ros/pronto_ros_conversions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 GPSHandlerROS::GPSHandlerROS(ros::NodeHandle &nh) : nh_(nh) {
     std::string prefix = "gps/";
@@ -12,7 +12,7 @@ GPSHandlerROS::GPSHandlerROS(ros::NodeHandle &nh) : nh_(nh) {
 }
 
 RBISUpdateInterface* GPSHandlerROS::processMessage(const pronto_msgs::GPSData *msg,
-                                                   MavStateEstimator *est)
+                                                   StateEstimator *est)
 {
     gpsDataFromROS(*msg, gps_meas_);
     return gps_module_->processMessage(&gps_meas_,

--- a/pronto_ros/src/index_meas_ros_handler.cpp
+++ b/pronto_ros/src/index_meas_ros_handler.cpp
@@ -1,7 +1,7 @@
 #include "pronto_ros/index_meas_ros_handler.hpp"
 #include "pronto_ros/pronto_ros_conversions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 IndexedMeasurementHandlerROS::IndexedMeasurementHandlerROS(const RBISUpdateInterface::sensor_enum &this_sensor) :
     index_module_(this_sensor)
@@ -10,7 +10,7 @@ IndexedMeasurementHandlerROS::IndexedMeasurementHandlerROS(const RBISUpdateInter
 }
 
 RBISUpdateInterface * IndexedMeasurementHandlerROS::processMessage(const pronto_msgs::IndexedMeasurement * msg,
-                                                                   MavStateEstimator* state_estimator)
+                                                                   StateEstimator* state_estimator)
 {
     indexMeasurementFromROS(*msg, index_msg_);
     return index_module_.processMessage(&index_msg_, state_estimator);
@@ -31,6 +31,6 @@ bool IndexedMeasurementHandlerROS::processMessageInit(const pronto_msgs::Indexed
                                             init_state,
                                             init_cov);
 }
-} // namespace MavStateEst
+} // namespace pronto
 
 

--- a/pronto_ros/src/init_message_ros_handler.cpp
+++ b/pronto_ros/src/init_message_ros_handler.cpp
@@ -6,7 +6,7 @@
 
 using namespace Eigen;
 
-namespace MavStateEst {
+namespace pronto {
 
 bool InitMessageHandlerROS::processMessageInit(const pronto_msgs::FilterState * msg,
                                             const std::map<std::string, bool> & sensors_initialized,
@@ -29,7 +29,7 @@ bool InitMessageHandlerROS::processMessageInit(const pronto_msgs::FilterState * 
  * on the fly.
  */
 RBISUpdateInterface * InitMessageHandlerROS::processMessage(const pronto_msgs::FilterState * msg,
-                                                         MavStateEstimator* state_estimator)
+                                                         StateEstimator* state_estimator)
 {
   filterStateFromROS(*msg, init_msg_);
   return init_module_.processMessage(&init_msg_, state_estimator);

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -5,7 +5,7 @@
 #include "pronto_ros/pronto_ros_conversions.hpp"
 
 
-namespace MavStateEst {
+namespace pronto {
 
 InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
 {
@@ -185,7 +185,7 @@ InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
     ins_module_ = InsModule(cfg, ins_to_body);
 }
 
-RBISUpdateInterface* InsHandlerROS::processMessage(const sensor_msgs::Imu *imu_msg, MavStateEstimator *est){
+RBISUpdateInterface* InsHandlerROS::processMessage(const sensor_msgs::Imu *imu_msg, StateEstimator *est){
     // keep one every downsample_factor messages
     if(counter++ % downsample_factor_ != 0){
         return NULL;
@@ -209,4 +209,4 @@ bool InsHandlerROS::processMessageInit(const sensor_msgs::Imu *imu_msg,
                                           init_cov);
 
 }
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/src/pose_msg_ros_handler.cpp
+++ b/pronto_ros/src/pose_msg_ros_handler.cpp
@@ -1,7 +1,7 @@
 #include "pronto_ros/pose_msg_ros_handler.hpp"
 #include "pronto_ros/pronto_ros_conversions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 PoseHandlerROS::PoseHandlerROS(ros::NodeHandle &nh) : nh_(nh) {
     PoseMeasConfig cfg;
@@ -36,7 +36,7 @@ PoseHandlerROS::PoseHandlerROS(ros::NodeHandle &nh) : nh_(nh) {
 }
 
 RBISUpdateInterface* PoseHandlerROS::processMessage(const geometry_msgs::PoseWithCovarianceStamped *msg,
-                                    MavStateEstimator *est)
+                                    StateEstimator *est)
 {
     poseMsgFromROS(*msg, pose_meas_);
     pose_module_->processMessage(&pose_meas_,est);

--- a/pronto_ros/src/pronto_ros_conversions.cpp
+++ b/pronto_ros/src/pronto_ros_conversions.cpp
@@ -2,7 +2,7 @@
 #include <tf_conversions/tf_eigen.h>
 #include <eigen_conversions/eigen_msg.h>
 
-namespace MavStateEst {
+namespace pronto {
 
 void gpsDataFromROS(const pronto_msgs::GPSData &ros_msg,
                     GPSMeasurement &msg)

--- a/pronto_ros/src/pronto_ros_node.cpp
+++ b/pronto_ros/src/pronto_ros_node.cpp
@@ -3,7 +3,7 @@
 #include "pronto_ros/ins_ros_handler.hpp"
 #include "pronto_ros/vicon_ros_handler.hpp"
 
-using namespace MavStateEst;
+using namespace pronto;
 
 
 int main(int argc, char** argv) {

--- a/pronto_ros/src/ros_frontend.cpp
+++ b/pronto_ros/src/ros_frontend.cpp
@@ -1,7 +1,7 @@
 #include "pronto_ros/ros_frontend.hpp"
 
-namespace MavStateEst {
-using SensorId = MavStateEst::ROSFrontEnd::SensorId;
+namespace pronto {
+using SensorId = pronto::ROSFrontEnd::SensorId;
 
 ROSFrontEnd::ROSFrontEnd(ros::NodeHandle& nh, bool verbose) :
     nh_(nh), verbose_(verbose)
@@ -173,7 +173,7 @@ bool ROSFrontEnd::initializeFilter()
     if(isFilterInitialized()){
         return true;
     }
-    state_est_.reset(new MavStateEstimator(new RBISResetUpdate(init_state,
+    state_est_.reset(new StateEstimator(new RBISResetUpdate(init_state,
                                                                init_cov,
                                                                RBISUpdateInterface::reset,
                                                                init_state.utime),

--- a/pronto_ros/src/scan_matcher_ros_handler.cpp
+++ b/pronto_ros/src/scan_matcher_ros_handler.cpp
@@ -3,7 +3,7 @@
 #include <tf_conversions/tf_eigen.h>
 #include "pronto_ros/pronto_ros_conversions.hpp"
 
-namespace MavStateEst {
+namespace pronto {
 
 using ScanMatchingMode = ScanMatcherModule::ScanMatchingMode;
 
@@ -114,7 +114,7 @@ ScanMatcherHandler::ScanMatcherHandler(ros::NodeHandle& nh) : nh_(nh)
 }
 
 RBISUpdateInterface * ScanMatcherHandler::processMessage(const nav_msgs::Odometry * msg,
-                                                         MavStateEstimator* state_estimator)
+                                                         StateEstimator* state_estimator)
 {
     poseMeasurementFromROS(*msg, pose_meas_);
     return scan_matcher_module_.processMessage(&pose_meas_, state_estimator);
@@ -130,4 +130,4 @@ bool ScanMatcherHandler::processMessageInit(const nav_msgs::Odometry *msg,
     return true;
 }
 
-} // namespace MavStateEst
+} // namespace pronto

--- a/pronto_ros/src/vicon_ros_handler.cpp
+++ b/pronto_ros/src/vicon_ros_handler.cpp
@@ -2,7 +2,7 @@
 #include "pronto_ros/pronto_ros_conversions.hpp"
 #include <tf/transform_listener.h>
 
-namespace MavStateEst {
+namespace pronto {
 
 ViconHandlerROS::ViconHandlerROS(ros::NodeHandle &nh) :
 nh_(nh)
@@ -68,7 +68,7 @@ nh_(nh)
 }
 
 RBISUpdateInterface* ViconHandlerROS::processMessage(const geometry_msgs::TransformStamped *msg,
-                                                     MavStateEstimator *est)
+                                                     StateEstimator *est)
 {
     rigidTransformFromROS(*msg, vicon_transf_);
     return vicon_module_->processMessage(&vicon_transf_,est);
@@ -88,4 +88,4 @@ bool ViconHandlerROS::processMessageInit(const geometry_msgs::TransformStamped *
                                              init_state,
                                              init_cov);
 }
-} // namespace MavStateEst
+} // namespace pronto


### PR DESCRIPTION
This is a thing I wanted to do for a long time. Pronto was born for MAVs so it contains the word MAV everywhere. But now it's used for many other robots so it should have a neutral name. I've replaced references to mavs with the pronto.