### PR TITLE
remove deprecated function setContactPoint

### DIFF
--- a/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_contact_forces.h
+++ b/pronto_quadruped_commons/include/pronto_quadruped_commons/feet_contact_forces.h
@@ -198,13 +198,6 @@ public:
                             const Vector3d& xdd = Vector3d::Zero(),
                             const Vector3d& omega = Vector3d::Zero(),
                             const Vector3d& omegad = Vector3d::Zero()) = 0;
-
-    /**
-     * @brief setContactPoint sets the contact point w.r.t. the center of the ball foot (in foot frame)
-     * @param foot_x
-     * @param foot_y
-     */
-    virtual void setContactPoint(LegID leg, double foot_x, double foot_y) = 0;
 };
 }  // namespace quadruped
 }  // namespace pronto


### PR DESCRIPTION
This removes from the interface a function that was never really used. It was intended to change the contact point along the shin for shin contact handling. Mostly forced by past developers for control purposes.

I expect the would need to be updated, e.g. pronto_anymal and pronto_vision60, etc.