### PR TITLE
[pronto_ros] Add joint_state_with_acceleration_republisher

### DIFF
--- a/pronto_ros/CMakeLists.txt
+++ b/pronto_ros/CMakeLists.txt
@@ -51,6 +51,16 @@ add_executable(lidar_odometry_visualizer src/lidar_odom_viz.cpp)
 target_link_libraries(lidar_odometry_visualizer ${catkin_LIBRARIES})
 add_dependencies(lidar_odometry_visualizer ${catkin_EXPORTED_TARGETS})
 
+# Node to republish pronto_msgs/JointStateWithAcceleration to sensor_msgs/JointState
+add_executable(joint_state_with_acceleration_republisher src/joint_state_with_acceleration_republisher.cpp)
+target_link_libraries(joint_state_with_acceleration_republisher ${pronto_msgs_LIBRARIES} ${sensor_msgs_LIBRARIES} ${catkin_LIBRARIES})
+install(
+  TARGETS joint_state_with_acceleration_republisher
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
 install(TARGETS ${PROJECT_NAME} lidar_odometry_visualizer ${PROJECT_NAME}_node
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/pronto_ros/src/joint_state_with_acceleration_republisher.cpp
+++ b/pronto_ros/src/joint_state_with_acceleration_republisher.cpp
@@ -1,0 +1,30 @@
+#include <pronto_msgs/JointStateWithAcceleration.h>
+#include <ros/node_handle.h>
+#include <sensor_msgs/JointState.h>
+
+ros::Publisher pub;
+
+void jointStateWithAccelerationCallback(const pronto_msgs::JointStateWithAcceleration::ConstPtr& msg)
+{
+    sensor_msgs::JointState out;
+    out.header = msg->header;
+    out.name = msg->name;
+    out.position = msg->position;
+    out.velocity = msg->velocity;
+    out.effort = msg->effort;
+
+    pub.publish(out);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "joint_state_with_acceleration_republisher");
+
+    ros::NodeHandle nh("~");
+    ros::Subscriber sub = nh.subscribe<pronto_msgs::JointStateWithAcceleration>("joint_states_with_acceleration", 10, jointStateWithAccelerationCallback, ros::TransportHints().tcpNoDelay());
+    pub = nh.advertise<sensor_msgs::JointState>("joint_states", 10);
+
+    ros::spin();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Simple node to republish a pronto_msgs/JointStateWithAcceleration as a sensor_msgs/JointState message dropping the acceleration. Useful when evaluating the impact of including joint acceleration information for state estimation