### PR TITLE
Add roll and pitch to yaw lock module

### DIFF
--- a/pronto_core/CMakeLists.txt
+++ b/pronto_core/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(${PRONTO_CORE_LIB} src/rbis.cpp
                                src/indexed_meas_module.cpp
                                src/init_message_module.cpp
                                src/gps_module.cpp
-                               src/pose_meas_module.cpp)
+                               src/pose_meas_module.cpp
+                               src/zero_vel_meas_module.cpp)
 
 target_link_libraries(${PRONTO_CORE_LIB} ${catkin_LIBRARIES})
 

--- a/pronto_core/CMakeLists.txt
+++ b/pronto_core/CMakeLists.txt
@@ -6,7 +6,9 @@ set(PRONTO_CORE_LIB ${PROJECT_NAME})
 
 add_compile_options(-Wall)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
 
 find_package(Eigen3 REQUIRED)
 

--- a/pronto_core/include/pronto_core/rbis_update_interface.hpp
+++ b/pronto_core/include/pronto_core/rbis_update_interface.hpp
@@ -10,7 +10,7 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 public:
   typedef enum {
-    ins, gps, vicon, laser, laser_gpf, scan_matcher, optical_flow, reset, invalid, rgbd, fovis, legodo, pose_meas, altimeter, airspeed, sideslip, init_message, viewer, yawlock
+    ins, gps, vicon, laser, laser_gpf, scan_matcher, optical_flow, reset, invalid, rgbd, fovis, legodo, pose_meas, zero_vel_meas, altimeter, airspeed, sideslip, init_message, viewer, yawlock
   } sensor_enum;
 
   int64_t utime;

--- a/pronto_core/include/pronto_core/zero_vel_meas_module.hpp
+++ b/pronto_core/include/pronto_core/zero_vel_meas_module.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "pronto_core/sensing_module.hpp"
+#include "pronto_core/definitions.hpp"
+
+namespace pronto {
+
+struct ZeroVelMeasConfig {
+    double r_zero_vel_meas;
+};
+
+class ZeroVelMeasModule : SensingModule<PoseMeasurement> {
+
+public:
+    // the indices and matrix will be 6 dimensional tops
+    typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, 6, 1> MeasVector;
+    typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 6, 6> MeasCovMatrix;
+    typedef Eigen::Matrix<int, Eigen::Dynamic, 1, 0, 6, 1> MeasIndices;
+
+public:
+    ZeroVelMeasModule(const ZeroVelMeasConfig& cfg);
+
+    RBISUpdateInterface* processMessage(const PoseMeasurement *msg,
+                                        StateEstimator *est);
+
+    bool processMessageInit(const PoseMeasurement *msg,
+                            const std::map<std::string, bool> &sensor_initialized,
+                            const RBIS &default_state,
+                            const RBIM &default_cov,
+                            RBIS &init_state,
+                            RBIM &init_cov);
+
+protected:
+  MeasIndices z_indices;
+  MeasVector z_meas;
+  MeasCovMatrix cov_zero_vel_meas;
+};
+} // namespace pronto

--- a/pronto_core/package.xml
+++ b/pronto_core/package.xml
@@ -17,6 +17,9 @@
 
   <license>LGPLv2.1</license>
 
+  <build_depend>roscpp</build_depend> 
+  <run_depend>roscpp</run_depend>
+
   <buildtool_depend>catkin</buildtool_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/pronto_core/src/ins_module.cpp
+++ b/pronto_core/src/ins_module.cpp
@@ -29,10 +29,11 @@ InsModule::InsModule(const InsConfig &config, const Eigen::Affine3d &ins_to_body
     accel_bias_initial(config.accel_bias_initial),
     accel_bias_recalc_at_start(config.accel_bias_recalc_at_start)
 {
-    cov_accel = std::pow(config.cov_accel, 2);
-    cov_gyro = std::pow(config.cov_gyro * M_PI / 180.0, 2);
-    cov_accel_bias = std::pow(config.cov_accel_bias, 2);
-    cov_gyro_bias = std::pow(config.cov_gyro_bias * M_PI / 180.0,2);
+    // Conversion is already done in ins_ros_handler.cpp
+    cov_accel = config.cov_accel;
+    cov_gyro = config.cov_gyro;
+    cov_accel_bias = config.cov_accel_bias;
+    cov_gyro_bias = config.cov_gyro_bias;
 }
 
 bool InsModule::allInitializedExcept(const std::map<std::string, bool> &_sensors_initialized,

--- a/pronto_core/src/rbis.cpp
+++ b/pronto_core/src/rbis.cpp
@@ -169,6 +169,16 @@ double matrixMeasurementGetKandCovDelta(const Eigen::MatrixXd & R,
   S = R;
   S.noalias() += C * cov * C.transpose();
 
+  // Check innovation covariance matrix symmetry
+  bool is_symmetric = S.isApprox(S.transpose(), 1e-8);
+  if (!is_symmetric) {
+      S = 0.5 * (S + S.transpose());
+  }
+
+  // Regularize to ensure innovation covariance matrix is positive semi-definite
+  double epsilon = 1e-12;
+  S.diagonal().array() += epsilon;
+
   LDLT<MatrixXd> Sldlt = LDLT<MatrixXd>(S);
   //  K = self->Sigma * H.transpose() * S.inverse();
   K.transpose() = Sldlt.solve(C * cov);

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -4,9 +4,9 @@
 
 namespace pronto {
 
-const char * RBISUpdateInterface::sensor_enum_chars = "igvlfsorxdukpabmtwy";
+const char * RBISUpdateInterface::sensor_enum_chars = "igvlfsorxdukpzabmtwy";
 const char * RBISUpdateInterface::sensor_enum_strings[] =
-    { "ins", "gps", "vicon", "laser", "laser_gpf", "scan_matcher", "optic_flow", "reset", "invalid", "rgbd", "fovis", "legodo", "pose_meas", "altimeter", "airspeed", "sideslip", "init_message", "viewer", "yawlock" };
+    { "ins", "gps", "vicon", "laser", "laser_gpf", "scan_matcher", "optic_flow", "reset", "invalid", "rgbd", "fovis", "legodo", "pose_meas", "zero_vel_meas", "altimeter", "airspeed", "sideslip", "init_message", "viewer", "yawlock" };
 
 RBISUpdateInterface::sensor_enum RBISUpdateInterface::sensor_enum_from_char(char sensor_char)
 {

--- a/pronto_core/src/rbis_update_interface.cpp
+++ b/pronto_core/src/rbis_update_interface.cpp
@@ -2,6 +2,7 @@
 #include "pronto_core/rotations.hpp"
 #include <iostream>
 #include <cmath> // For std::isnan
+#include <ros/ros.h> // For logging
 
 namespace pronto {
 
@@ -169,7 +170,7 @@ void RBISIndexedMeasurement::updateFilter(const RBIS & prior_state, const RBIM &
   // Updated log-likehood accumulates the new measurement's contribution 
   loglikelihood = prior_loglikelihood + current_loglikelihood;
 
-  // Check if log-likelihood is NaN
+  // Check if loglikelihood is NaN
   if (std::isnan(loglikelihood)) {
     // Log a warning message
     ROS_WARN_STREAM("Log-likelihood is NaN. Ignoring Measurement. Resetting posterior to prior.");
@@ -193,7 +194,7 @@ void RBISIndexedPlusOrientationMeasurement::updateFilter(const RBIS & prior_stat
   RBIM prior_cov_copy = prior_cov; // Make a mutable copy
 
   // Check prior covariance matrix symmetry
-  bool is_symmetric = prior_cov_copy.isApprox(prior_cov_copy.transpose(), 1e-8);
+  bool is_symmetric = prior_cov_copy.isApprox(prior_cov_copy.transpose(), 1e-8); // Symmetry check
   if (!is_symmetric) {
       prior_cov_copy = 0.5 * (prior_cov_copy + prior_cov_copy.transpose());
   }
@@ -238,7 +239,7 @@ void RBISIndexedPlusOrientationMeasurement::updateFilter(const RBIS & prior_stat
   // Updated log-likehood accumulates the new measurement's contribution 
   loglikelihood = prior_loglikelihood + current_likelihood;
 
-  // Check if log-likelihood is NaN
+// Check if loglikelihood is NaN
   if (std::isnan(loglikelihood)) {
     // Log a warning message
     ROS_WARN_STREAM("Log-likelihood is NaN. Ignoring Measurement. Resetting posterior to prior.");

--- a/pronto_core/src/zero_vel_meas_module.cpp
+++ b/pronto_core/src/zero_vel_meas_module.cpp
@@ -5,23 +5,25 @@ namespace pronto {
 
 ZeroVelMeasModule::ZeroVelMeasModule(const ZeroVelMeasConfig &cfg)
 {
-    std::cout << "ZeroVelMeasModule::ZeroVelMeasModule" << std::endl;  // this prints
+    std::cout << "ZeroVelMeasModule::ZeroVelMeasModule" << std::endl;
 
     // Set indices
-    z_meas.resize(3);
-    z_indices.resize(3);
+    z_meas.resize(6);
+    z_indices.resize(6);
     z_indices.head<3>() = RBIS::velocityInds();
+    z_indices.tail<3>() = RBIS::angularVelocityInds();
 
     // Set covariance
-    cov_zero_vel_meas.resize(3, 3);
+    cov_zero_vel_meas.resize(6, 6);
     cov_zero_vel_meas.setZero();
-    cov_zero_vel_meas.topLeftCorner<3, 3>() = std::pow(cfg.r_zero_vel_meas, 2) * Eigen::Matrix3d::Identity();
+    cov_zero_vel_meas = std::pow(cfg.r_zero_vel_meas, 2) * Eigen::MatrixXd::Identity(6, 6);
 }
 
-RBISUpdateInterface* ZeroVelMeasModule::processMessage(const PoseMeasurement *msg,
-                                                    StateEstimator *est)
+RBISUpdateInterface* ZeroVelMeasModule::processMessage(const PoseMeasurement *msg, StateEstimator *est)
 {
     z_meas.head<3>() = msg->linear_vel;
+    z_meas.tail<3>() = msg->angular_vel;
+
     return new RBISIndexedMeasurement(z_indices,
                                       z_meas,
                                       cov_zero_vel_meas,
@@ -38,11 +40,9 @@ bool ZeroVelMeasModule::processMessageInit(const PoseMeasurement *msg,
 {
     init_state.utime = msg->utime;
     init_state.velocity() = msg->linear_vel;
+    init_state.angularVelocity() = msg->angular_vel;
     init_cov.block<3, 3>(RBIS::velocity_ind, RBIS::velocity_ind) = cov_zero_vel_meas.topLeftCorner<3, 3>();
-
-    std::cout << "Initialized ZeroVel velocity: "
-              << init_state.velocity().transpose() << std::endl;
-
+    init_cov.block<3, 3>(RBIS::angular_velocity_ind, RBIS::angular_velocity_ind) = cov_zero_vel_meas.bottomRightCorner<3, 3>();
     return true;
 }
 } // namespace pronto

--- a/pronto_core/src/zero_vel_meas_module.cpp
+++ b/pronto_core/src/zero_vel_meas_module.cpp
@@ -1,0 +1,48 @@
+#include "pronto_core/zero_vel_meas_module.hpp"
+#include <iostream>
+
+namespace pronto {
+
+ZeroVelMeasModule::ZeroVelMeasModule(const ZeroVelMeasConfig &cfg)
+{
+    std::cout << "ZeroVelMeasModule::ZeroVelMeasModule" << std::endl;  // this prints
+
+    // Set indices
+    z_meas.resize(3);
+    z_indices.resize(3);
+    z_indices.head<3>() = RBIS::velocityInds();
+
+    // Set covariance
+    cov_zero_vel_meas.resize(3, 3);
+    cov_zero_vel_meas.setZero();
+    cov_zero_vel_meas.topLeftCorner<3, 3>() = std::pow(cfg.r_zero_vel_meas, 2) * Eigen::Matrix3d::Identity();
+}
+
+RBISUpdateInterface* ZeroVelMeasModule::processMessage(const PoseMeasurement *msg,
+                                                    StateEstimator *est)
+{
+    z_meas.head<3>() = msg->linear_vel;
+    return new RBISIndexedMeasurement(z_indices,
+                                      z_meas,
+                                      cov_zero_vel_meas,
+                                      RBISUpdateInterface::zero_vel_meas,
+                                      msg->utime);
+}
+
+bool ZeroVelMeasModule::processMessageInit(const PoseMeasurement *msg,
+                                        const std::map<std::string, bool> &sensor_initialized,
+                                        const RBIS &default_state,
+                                        const RBIM &default_cov,
+                                        RBIS &init_state,
+                                        RBIM &init_cov)
+{
+    init_state.utime = msg->utime;
+    init_state.velocity() = msg->linear_vel;
+    init_cov.block<3, 3>(RBIS::velocity_ind, RBIS::velocity_ind) = cov_zero_vel_meas.topLeftCorner<3, 3>();
+
+    std::cout << "Initialized ZeroVel velocity: "
+              << init_state.velocity().transpose() << std::endl;
+
+    return true;
+}
+} // namespace pronto

--- a/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/ImuBiasLock.hpp
@@ -40,11 +40,10 @@ class ImuBiasLock : public DualSensingModule<ImuMeasurement,pronto::JointState>
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 public:
-    // the measurement and index sizes is 8: 3 for gyro bias, 3 for accel bias
-    // and 2 for roll/pitch estimation
-    using MeasVector = Eigen::Matrix<double, 8, 1>;
-    using IndexVector = Eigen::Matrix<int, 8, 1>;
-    using CovMatrix = Eigen::Matrix<double, 8, 8>;
+    // the measurement and index sizes is 6: 3 for gyro bias, 3 for accel bias
+    using MeasVector = Eigen::Matrix<double, 6, 1>;
+    using IndexVector = Eigen::Matrix<int, 6, 1>;
+    using CovMatrix = Eigen::Matrix<double, 6, 6>;
 public:
     ImuBiasLock(const Eigen::Isometry3d& ins_to_body_ = Eigen::Isometry3d::Identity(),
                 const ImuBiasLockConfig& cfg = ImuBiasLockConfig());

--- a/pronto_quadruped/include/pronto_quadruped/StanceEstimator.hpp
+++ b/pronto_quadruped/include/pronto_quadruped/StanceEstimator.hpp
@@ -98,6 +98,9 @@ public:
 
     virtual ~StanceEstimator() = default;
 
+    // Declare a virtual function for publishing GRF (to be overridden by derived classes)
+    virtual void publishGRF(const LegVectorMap& grf) {}
+
     /**
      * @brief setJointStates
      * @param q

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -36,7 +36,6 @@ ImuBiasLock::ImuBiasLock(const Eigen::Isometry3d& ins_to_body,
   z_indices.head<3>() = RBIS::gyroBiasInds();
   // accel bias indices
   z_indices.block<3,1>(3,0) = RBIS::accelBiasInds();
-  // roll and pitch indices
   gravity_vector_ = Eigen::Vector3d::UnitZ() * g_val;
 
   z_covariance = CovMatrix::Zero();

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -37,7 +37,6 @@ ImuBiasLock::ImuBiasLock(const Eigen::Isometry3d& ins_to_body,
   // accel bias indices
   z_indices.block<3,1>(3,0) = RBIS::accelBiasInds();
   // roll and pitch indices
-  z_indices.tail<2>(0) << RBIS::chi_ind, RBIS::chi_ind+1;
   gravity_vector_ = Eigen::Vector3d::UnitZ() * g_val;
 
   z_covariance = CovMatrix::Zero();

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -142,25 +142,7 @@ bool ImuBiasLock::isStatic(const pronto::JointState &state)
     std::cerr << "++++++++++++++ not enough joints " << state.joint_effort.size() << " < 12 !!!\n";
     return false;
   }
-
-  // TODO: The knee joint order is hard-coded here!
-  if(std::abs(state.joint_effort[2]) < torque_threshold_){
-    if (debug_) std::cout << "++++++++++++++ [LF] not enough torque " << std::abs(state.joint_effort[2]) << " < " << torque_threshold_ << "\n";
-    return false;
-  }
-  if(std::abs(state.joint_effort[5]) < torque_threshold_){
-    if (debug_) std::cout << "++++++++++++++ [RF] not enough torque " << std::abs(state.joint_effort[5]) << " < " << torque_threshold_ << "\n";
-    return false;
-  }
-  if(std::abs(state.joint_effort[8]) < torque_threshold_){
-    if (debug_) std::cout << "++++++++++++++ [LH] not enough torque " << std::abs(state.joint_effort[8]) << " < " << torque_threshold_ << "\n";
-    return false;
-  }
-  if(std::abs(state.joint_effort[11]) < torque_threshold_){
-    if (debug_) std::cout << "++++++++++++++ [RH] not enough torque " << std::abs(state.joint_effort[11]) << " < " << torque_threshold_ << "\n";
-    return false;
-  }
-
+  
   // check that joint velocities are not bigger than eps
   for (auto el : state.joint_velocity){
     if (std::abs(el) > eps_){

--- a/pronto_quadruped/src/ImuBiasLock.cpp
+++ b/pronto_quadruped/src/ImuBiasLock.cpp
@@ -65,8 +65,8 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
     gyro_bias_history_.push_back(current_omega_);
     accel_bias_history_.push_back(current_accel_corrected_);
     if(gyro_bias_history_.size() > max_size){
-      std::cout << "Stop recording (size too big)" << std::endl;
-      std::cout << gyro_bias_history_.size() << std::endl;
+      // std::cout << "Stop recording (size too big)" << std::endl;
+      // std::cout << gyro_bias_history_.size() << std::endl;
       do_record_ = false;
     } else {
       return nullptr;
@@ -78,7 +78,7 @@ RBISUpdateInterface* ImuBiasLock::processMessage(const ImuMeasurement *msg,
   if(!do_record_ && !gyro_bias_history_.empty()) {
     if(gyro_bias_history_.size() < min_size)
     {
-      std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << std::endl;
+      // std::cerr << "Cleaning too short history " << gyro_bias_history_.size() << " < " << min_size << std::endl;
       gyro_bias_history_.clear();
       accel_bias_history_.clear();
       return nullptr;

--- a/pronto_quadruped/src/StanceEstimator.cpp
+++ b/pronto_quadruped/src/StanceEstimator.cpp
@@ -241,7 +241,13 @@ LegVectorMap StanceEstimator::getGRF() {
 }
 
 bool StanceEstimator::getGRF(LegVectorMap& grf){
- return feet_contact_forces_.getFeetGRF(q_, qd_, tau_, orient_, grf, qdd_, xd_, xdd_, omega_, omegad_);
+    bool success = feet_contact_forces_.getFeetGRF(q_, qd_, tau_, orient_, grf, qdd_, xd_, xdd_, omega_, omegad_);
+    
+    if (success) {
+        publishGRF(grf);
+    }
+    
+    return success;
 }
 
 void StanceEstimator::getGrf_W(LegVectorMap & grf) {

--- a/pronto_quadruped_ros/include/pronto_quadruped_ros/stance_estimator_ros.hpp
+++ b/pronto_quadruped_ros/include/pronto_quadruped_ros/stance_estimator_ros.hpp
@@ -25,6 +25,7 @@
 
 #include <pronto_quadruped/StanceEstimator.hpp>
 #include <ros/node_handle.h>
+#include <std_msgs/Float32MultiArray.h>
 
 namespace pronto {
 namespace quadruped {
@@ -33,8 +34,10 @@ class StanceEstimatorROS : public StanceEstimator {
 public:
     StanceEstimatorROS(ros::NodeHandle& nh,
                        FeetContactForces& feet_forces);
+    void publishGRF(const LegVectorMap& grf);
 private:
     ros::NodeHandle& nh_;
+    ros::Publisher foot_grf_pub_;  // The publisher for the GRFs
 };
 }  // namespace quadruped
 }  // namespace pronto

--- a/pronto_quadruped_ros/src/legodo_handler_ros.cpp
+++ b/pronto_quadruped_ros/src/legodo_handler_ros.cpp
@@ -279,7 +279,7 @@ LegodoHandlerBase::Update* LegodoHandlerBase::computeVelocity(){
                                                 Update::legodo,
                                                 utime_);
   } else {
-    if (debug_) ROS_WARN("[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
+    if (debug_) ROS_INFO_STREAM("[LegodoHandlerBase::computeVelocity] Could not estimate velocity");
   }
   return nullptr;
 }

--- a/pronto_quadruped_ros/src/stance_estimator_ros.cpp
+++ b/pronto_quadruped_ros/src/stance_estimator_ros.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "pronto_quadruped_ros/stance_estimator_ros.hpp"
+#include <std_msgs/Float32MultiArray.h>
 
 namespace pronto {
 namespace quadruped {
@@ -30,6 +31,9 @@ StanceEstimatorROS::StanceEstimatorROS(ros::NodeHandle &nh,
                                        FeetContactForces &feet_forces) :
      StanceEstimator(feet_forces), nh_(nh)
 {
+    // Initialize the publisher for GRF values
+    foot_grf_pub_ = nh_.advertise<std_msgs::Float32MultiArray>("/pronto/foot_grfs", 10);
+
     // get parameters for the leg odometry
     std::string legodo_prefix = "legodo/";
 
@@ -86,6 +90,29 @@ StanceEstimatorROS::StanceEstimatorROS(ros::NodeHandle &nh,
     }
     setParams(beta, stance_threshold, hysteresis_low, hysteresis_high, stance_hysteresis_delay_low, stance_hysteresis_delay_high);
 }
+
+void StanceEstimatorROS::publishGRF(const LegVectorMap& grf) {
+    std_msgs::Float32MultiArray grf_msg;
+
+    grf_msg.data.push_back(grf[LegID::LF][0]);
+    grf_msg.data.push_back(grf[LegID::LF][1]);
+    grf_msg.data.push_back(grf[LegID::LF][2]);
+
+    grf_msg.data.push_back(grf[LegID::RF][0]);
+    grf_msg.data.push_back(grf[LegID::RF][1]);
+    grf_msg.data.push_back(grf[LegID::RF][2]);
+
+    grf_msg.data.push_back(grf[LegID::LH][0]);
+    grf_msg.data.push_back(grf[LegID::LH][1]);
+    grf_msg.data.push_back(grf[LegID::LH][2]);
+
+    grf_msg.data.push_back(grf[LegID::RH][0]);
+    grf_msg.data.push_back(grf[LegID::RH][1]);
+    grf_msg.data.push_back(grf[LegID::RH][2]);
+
+    foot_grf_pub_.publish(grf_msg);
+}
+
 
 }  // namespace quadruped
 }  // namespace pronto

--- a/pronto_quadruped_ros/src/stance_estimator_ros.cpp
+++ b/pronto_quadruped_ros/src/stance_estimator_ros.cpp
@@ -32,7 +32,7 @@ StanceEstimatorROS::StanceEstimatorROS(ros::NodeHandle &nh,
      StanceEstimator(feet_forces), nh_(nh)
 {
     // Initialize the publisher for GRF values
-    foot_grf_pub_ = nh_.advertise<std_msgs::Float32MultiArray>("/pronto/foot_grfs", 10);
+    foot_grf_pub_ = nh_.advertise<std_msgs::Float32MultiArray>("/pronto/foot_grf_estimate", 10);
 
     // get parameters for the leg odometry
     std::string legodo_prefix = "legodo/";

--- a/pronto_ros/CMakeLists.txt
+++ b/pronto_ros/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(${PROJECT_NAME} src/ins_ros_handler.cpp
                             src/lidar_odometry_ros_handler.cpp
                             src/ros_frontend.cpp
                             src/pose_msg_ros_handler.cpp
+                            src/zero_vel_msg_ros_handler.cpp
                             src/pronto_ros_conversions.cpp)
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
+++ b/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
@@ -7,6 +7,7 @@
 #include <sensor_msgs/Imu.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/JointState.h>
@@ -35,6 +36,9 @@ void poseMsgFromROS(const geometry_msgs::PoseWithCovarianceStamped &msg,
 
 void poseMsgFromROS(const geometry_msgs::PoseStamped &msg,
                     PoseMeasurement &pose_meas);
+
+void zeroVelMsgFromROS(const geometry_msgs::TwistStamped &msg,
+                    PoseMeasurement &zero_vel_meas);
 
 void poseMeasurementFromROS(const nav_msgs::Odometry& ros_msg,
                             PoseMeasurement& msg);

--- a/pronto_ros/include/pronto_ros/zero_vel_msg_ros_handler.hpp
+++ b/pronto_ros/include/pronto_ros/zero_vel_msg_ros_handler.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <ros/node_handle.h>
+#include <pronto_core/zero_vel_meas_module.hpp>
+#include <geometry_msgs/TwistStamped.h>
+
+namespace pronto {
+
+class ZeroVelHandlerROS : public SensingModule<geometry_msgs::TwistStamped> {
+public:
+    ZeroVelHandlerROS(ros::NodeHandle& nh);
+
+    RBISUpdateInterface* processMessage(const geometry_msgs::TwistStamped *msg,
+                                        StateEstimator *est);
+
+    bool processMessageInit(const geometry_msgs::TwistStamped *msg,
+                            const std::map<std::string, bool> &sensor_initialized,
+                            const RBIS &default_state,
+                            const RBIM &default_cov,
+                            RBIS &init_state,
+                            RBIM &init_cov);
+private:
+    ros::NodeHandle& nh_;
+    std::shared_ptr<ZeroVelMeasModule> zero_vel_module_;
+    PoseMeasurement zero_vel_meas_;
+};
+
+}

--- a/pronto_ros/src/pronto_ros_conversions.cpp
+++ b/pronto_ros/src/pronto_ros_conversions.cpp
@@ -102,9 +102,8 @@ void poseMsgFromROS(const geometry_msgs::PoseStamped &msg,
 void zeroVelMsgFromROS(const geometry_msgs::TwistStamped &msg,
                     PoseMeasurement &zero_vel_meas)
 {
-  zero_vel_meas.linear_vel << msg.twist.linear.x,
-      msg.twist.linear.y,
-      msg.twist.linear.z;
+  zero_vel_meas.linear_vel << msg.twist.linear.x, msg.twist.linear.y, msg.twist.linear.z;
+  zero_vel_meas.angular_vel << msg.twist.angular.x, msg.twist.angular.y, msg.twist.angular.z;
   zero_vel_meas.utime = (uint64_t) msg.header.stamp.toNSec() / 1000;
 }
 

--- a/pronto_ros/src/pronto_ros_conversions.cpp
+++ b/pronto_ros/src/pronto_ros_conversions.cpp
@@ -99,6 +99,15 @@ void poseMsgFromROS(const geometry_msgs::PoseStamped &msg,
   pose_meas.utime = (uint64_t) msg.header.stamp.toNSec() / 1000;
 }
 
+void zeroVelMsgFromROS(const geometry_msgs::TwistStamped &msg,
+                    PoseMeasurement &zero_vel_meas)
+{
+  zero_vel_meas.linear_vel << msg.twist.linear.x,
+      msg.twist.linear.y,
+      msg.twist.linear.z;
+  zero_vel_meas.utime = (uint64_t) msg.header.stamp.toNSec() / 1000;
+}
+
 void poseMeasurementFromROS(const nav_msgs::Odometry &ros_msg,
                             PoseMeasurement &msg)
 {

--- a/pronto_ros/src/zero_vel_msg_ros_handler.cpp
+++ b/pronto_ros/src/zero_vel_msg_ros_handler.cpp
@@ -1,0 +1,39 @@
+#include "pronto_ros/zero_vel_msg_ros_handler.hpp"
+#include "pronto_ros/pronto_ros_conversions.hpp"
+
+namespace pronto {
+
+ZeroVelHandlerROS::ZeroVelHandlerROS(ros::NodeHandle &nh) : nh_(nh) {
+    ZeroVelMeasConfig cfg;
+    std::string prefix = "zero_vel_meas/";
+    if(!nh_.getParam(prefix + "r_zero_vel_meas", cfg.r_zero_vel_meas)){
+        ROS_WARN("Param \"r_zero_vel_meas\" not found. Setting to 0.0001");
+        cfg.r_zero_vel_meas = 0.0001;  // default covariance
+    }
+
+    zero_vel_module_.reset(new ZeroVelMeasModule(cfg));
+}
+
+RBISUpdateInterface* ZeroVelHandlerROS::processMessage(const geometry_msgs::TwistStamped *msg,
+                                    StateEstimator *est)
+{
+    zeroVelMsgFromROS(*msg, zero_vel_meas_);
+    return zero_vel_module_->processMessage(&zero_vel_meas_,est);
+}
+
+bool ZeroVelHandlerROS::processMessageInit(const geometry_msgs::TwistStamped *msg,
+                        const std::map<std::string, bool> &sensor_initialized,
+                        const RBIS &default_state,
+                        const RBIM &default_cov,
+                        RBIS &init_state,
+                        RBIM &init_cov)
+{
+    zeroVelMsgFromROS(*msg, zero_vel_meas_);
+    return zero_vel_module_->processMessageInit(&zero_vel_meas_,
+                                            sensor_initialized,
+                                            default_state,
+                                            default_cov,
+                                            init_state,
+                                            init_cov);
+}
+}


### PR DESCRIPTION
To reduce orientation drift after motion stops, roll and pitch states were added to the yaw lock module. An error was also fixed in which the IMU `q` config values were being converted to covariances (squared and converted to radians) twice -- resulting in tiny covariance values.